### PR TITLE
Add support for Hydrojet_Pro

### DIFF
--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -17,6 +17,7 @@ class BestwayDeviceType(Enum):
     AIRJET_SPA = "Airjet"
     AIRJET_V01_SPA = "Airjet V01"
     HYDROJET_SPA = "Hydrojet"
+    HYDROJET_PRO = "Hydrojet Pro"
     POOL_FILTER = "Pool Filter"
     UNKNOWN = "Unknown"
 
@@ -30,6 +31,8 @@ class BestwayDeviceType(Enum):
             return BestwayDeviceType.AIRJET_V01_SPA
         if product_name == "Hydrojet":
             return BestwayDeviceType.HYDROJET_SPA
+        if product_name == "Hydrojet_Pro":
+            return BestwayDeviceType.HYDROJET_PRO
         if product_name == "泳池过滤器":
             # Chinese translates to "pool filter"
             return BestwayDeviceType.POOL_FILTER

--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -17,7 +17,7 @@ class BestwayDeviceType(Enum):
     AIRJET_SPA = "Airjet"
     AIRJET_V01_SPA = "Airjet V01"
     HYDROJET_SPA = "Hydrojet"
-    HYDROJET_PRO = "Hydrojet Pro"
+    HYDROJET_PRO_SPA = "Hydrojet Pro"
     POOL_FILTER = "Pool Filter"
     UNKNOWN = "Unknown"
 
@@ -32,7 +32,7 @@ class BestwayDeviceType(Enum):
         if product_name == "Hydrojet":
             return BestwayDeviceType.HYDROJET_SPA
         if product_name == "Hydrojet_Pro":
-            return BestwayDeviceType.HYDROJET_PRO
+            return BestwayDeviceType.HYDROJET_PRO_SPA
         if product_name == "泳池过滤器":
             # Chinese translates to "pool filter"
             return BestwayDeviceType.POOL_FILTER

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -40,10 +40,11 @@ async def async_setup_entry(
     for device_id, device in coordinator.api.devices.items():
         if device.device_type == BestwayDeviceType.AIRJET_SPA:
             entities.append(AirjetSpaThermostat(coordinator, config_entry, device_id))
+
         if device.device_type in [
             BestwayDeviceType.AIRJET_V01_SPA,
             BestwayDeviceType.HYDROJET_SPA,
-            BestwayDeviceType.HYDROJET_PRO,
+            BestwayDeviceType.HYDROJET_PRO_SPA,
         ]:
             entities.append(
                 AirjetV01HydrojetSpaThermostat(coordinator, config_entry, device_id)

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
         if device.device_type in [
             BestwayDeviceType.AIRJET_V01_SPA,
             BestwayDeviceType.HYDROJET_SPA,
+            BestwayDeviceType.HYDROJET_PRO,
         ]:
             entities.append(
                 AirjetV01HydrojetSpaThermostat(coordinator, config_entry, device_id)

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -85,7 +85,7 @@ async def async_setup_entry(
 
         if device.device_type in [
             BestwayDeviceType.HYDROJET_SPA,
-            BestwayDeviceType.HYDROJET_PRO,
+            BestwayDeviceType.HYDROJET_PRO_SPA,
         ]:
             entities.append(
                 ThreeWaySpaBubblesSelect(

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -83,7 +83,10 @@ async def async_setup_entry(
                 )
             )
 
-        if device.device_type == BestwayDeviceType.HYDROJET_SPA:
+        if device.device_type in [
+            BestwayDeviceType.HYDROJET_SPA,
+            BestwayDeviceType.HYDROJET_PRO,
+        ]:
             entities.append(
                 ThreeWaySpaBubblesSelect(
                     coordinator,

--- a/custom_components/bestway/sensor.py
+++ b/custom_components/bestway/sensor.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
         if device_info.device_type in [
             BestwayDeviceType.AIRJET_SPA,
             BestwayDeviceType.HYDROJET_SPA,
-            BestwayDeviceType.HYDROJET_PRO,
+            BestwayDeviceType.HYDROJET_PRO_SPA,
         ]:
             name_prefix = "Spa"
         elif device_info.device_type == BestwayDeviceType.POOL_FILTER:

--- a/custom_components/bestway/sensor.py
+++ b/custom_components/bestway/sensor.py
@@ -40,6 +40,7 @@ async def async_setup_entry(
         if device_info.device_type in [
             BestwayDeviceType.AIRJET_SPA,
             BestwayDeviceType.HYDROJET_SPA,
+            BestwayDeviceType.HYDROJET_PRO,
         ]:
             name_prefix = "Spa"
         elif device_info.device_type == BestwayDeviceType.POOL_FILTER:

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -168,7 +168,7 @@ async def async_setup_entry(
 
         if device.device_type in [
             BestwayDeviceType.HYDROJET_SPA,
-            BestwayDeviceType.HYDROJET_PRO,
+            BestwayDeviceType.HYDROJET_PRO_SPA,
         ]:
             entities.extend(
                 [

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -166,7 +166,10 @@ async def async_setup_entry(
                 ]
             )
 
-        if device.device_type == BestwayDeviceType.HYDROJET_SPA:
+        if device.device_type in [
+            BestwayDeviceType.HYDROJET_SPA,
+            BestwayDeviceType.HYDROJET_PRO,
+        ]:
             entities.extend(
                 [
                     BestwaySwitch(

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -6,19 +6,20 @@ Bestway devices change over time, so new devices can sometimes require changes t
 
 Raise an issue or log a pull request to update this list. Please do not suggest updates based on marketing material - only trust values that have been observed in the integration logs.
 
-| Model                                 | Protocol    |
-| ------------------------------------- | ----------- |
-| Lay-Z-Spa Dominica HydroJet           | Hydrojet    |
-| Lay-Z-Spa Milan AirJet Plus           | Airjet      |
-| Lay-Z-Spa Santorini HydroJet Pro      | Hydrojet    |
-| SaluSpa Coronado EnergySense          | Airjet_V01  |
-| Bestway Smart Touch Wi-Fi Filter Pump | Pool Filter |
+| Model                                 | Protocol     |
+| ------------------------------------- | ------------ |
+| Lay-Z-Spa Dominica HydroJet           | Hydrojet     |
+| Lay-Z-Spa Maldives HydroJet Pro       | Hydrojet_Pro |
+| Lay-Z-Spa Milan AirJet Plus           | Airjet       |
+| SaluSpa Coronado EnergySense          | Airjet_V01   |
+| Bestway Smart Touch Wi-Fi Filter Pump | Pool Filter  |
 
 ## Protocol support
 
-| Protocol    | Supported          |
-| ----------- | ------------------ |
-| Airjet      | :white_check_mark: |
-| Airjet_V01  | :white_check_mark: |
-| Hydrojet    | :white_check_mark: |
-| Pool Filter | :white_check_mark: |
+| Protocol     | Supported          |
+| ------------ | ------------------ |
+| Airjet       | :white_check_mark: |
+| Airjet_V01   | :white_check_mark: |
+| Hydrojet     | :white_check_mark: |
+| Hydrojet_Pro | :white_check_mark: |
+| Pool Filter  | :white_check_mark: |


### PR DESCRIPTION
With this script:

```
from bestway.api import BestwayApi
import aiohttp
import asyncio

async def main():
    async with aiohttp.ClientSession() as session:
        token = await BestwayApi.get_user_token(session, 'XXX', 'XXX', 'https://usapi.gizwits.com')
        api = BestwayApi(session, token.user_token, 'https://usapi.gizwits.com')
        print('@@@', await api.refresh_bindings())
        print('!!!', await api.fetch_data())

asyncio.run(main())
```

I got the following output for my Hydrojet Pro:

```
@@@ Status for unknown device type 'Hydrojet_Pro' returned: {"E19": 0, "E18": 0, "E32": 1, "E31": 0, "E30": 0, "E11": 0, "E10": 0, "E13": 0, "E12": 0, "E15": 0, "E14": 0, "E17": 0, "E16": 0, "word5": 12747, "word4": 0, "word7": 39, "word6": 0, "word1": 0, "word0": 0, "E29": 0, "word2": 12747, "option6": 10244, "ver": 934, "E22": 0, "jet": 0, "E23": 0, "power": 1, "Tnow": 39, "option7": 10260, "option4": 60, "option5": 27175, "option2": 0, "option3": 30, "option0": 59940, "option1": 59940, "E24": 0, "E25": 0, "E26": 0, "E27": 0, "E20": 0, "E21": 0, "E08": 0, "E09": 0, "E06": 0, "E07": 0, "E04": 0, "E05": 0, "E02": 0, "E03": 0, "E01": 0, "bit7": 1, "heat": 4, "Tunit": 1, "wave": 0, "word3": 0, "Tset": 39, "filter": 2, "E28": 0, "bit6": 1, "bit5": 0, "bit4": 0, "bit3": 0, "bit2": 1}
!!! BestwayApiResults(devices={'rp5Hx6xMxGGkS27hvpICnO': BestwayDeviceStatus(timestamp=1708322029, attrs={'E19': 0, 'E18': 0, 'E32': 1, 'E31': 0, 'E30': 0, 'E11': 0, 'E10': 0, 'E13': 0, 'E12': 0, 'E15': 0, 'E14': 0, 'E17': 0, 'E16': 0, 'word5': 12747, 'word4': 0, 'word7': 39, 'word6': 0, 'word1': 0, 'word0': 0, 'E29': 0, 'word2': 12747, 'option6': 10244, 'ver': 934, 'E22': 0, 'jet': 0, 'E23': 0, 'power': 1, 'Tnow': 39, 'option7': 10260, 'option4': 60, 'option5': 27175, 'option2': 0, 'option3': 30, 'option0': 59940, 'option1': 59940, 'E24': 0, 'E25': 0, 'E26': 0, 'E27': 0, 'E20': 0, 'E21': 0, 'E08': 0, 'E09': 0, 'E06': 0, 'E07': 0, 'E04': 0, 'E05': 0, 'E02': 0, 'E03': 0, 'E01': 0, 'bit7': 1, 'heat': 4, 'Tunit': 1, 'wave': 0, 'word3': 0, 'Tset': 39, 'filter': 2, 'E28': 0, 'bit6': 1, 'bit5': 0, 'bit4': 0, 'bit3': 0, 'bit2': 1})})
```

Almost all the fields referenced by the Hydrojet code are there - but the error codes are different, so I added a new error code sensor. I only included the codes in the manual at https://support.bestwayaftersales.co.uk/wp-content/uploads/2020/01/Maldives-HJ-Pro-2020.pdf , although my API output didn't have `earth` so I've made it not raise if that key is missing.

I'd like to test this in my HA setup, do I just add my own repo as a custom repo? Or are there extra steps like publishing it to HACS?