### PR TITLE
Adjust Bubbles changes so medium and off work on airjet consistently and adjust Airjet HVAC running logic

### DIFF
--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -126,7 +126,7 @@ class BubblesMapping:
 
 
 BV = BubblesValues
-AIRJET_V01_BUBBLES_MAP = BubblesMapping(BV(0), BV(50, [50, 51]), BV(100))
+AIRJET_V01_BUBBLES_MAP = BubblesMapping(BV(0), BV(50, [40, 41, 50, 51]), BV(100))
 HYDROJET_BUBBLES_MAP = BubblesMapping(BV(0), BV(40), BV(100))
 
 

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -186,15 +186,15 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
         """Return the current mode (HEAT or OFF)."""
         if not self.status:
             return None
-        return HVACMode.HEAT if self.status.attrs["heat"] == 3 else HVACMode.OFF
+        return HVACMode.HEAT if self.status.attrs["heat"] > 0 else HVACMode.OFF
 
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running action (HEATING or IDLE)."""
         if not self.status:
             return None
-        heat_on = self.status.attrs["heat"] == HydrojetHeat.ON
-        target_reached = self.status.attrs["word3"] == 1
+        heat_on = self.status.attrs["heat"] > 0
+        target_reached = self.status.attrs["heat"] == 4
         return (
             HVACAction.HEATING if (heat_on and not target_reached) else HVACAction.IDLE
         )


### PR DESCRIPTION
Properly allows setting bubbles to medium and off without needing to change to max first

Fixes the HVAC heating issue after first sync on Airjets