### PR TITLE
feat: v02 device support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 .venv
 .coverage
 .idea
+node_modules

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -14,6 +14,8 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .bestway.api import BestwayApi
 from .bestway.websocket import GizwitsWebSocket
 from .const import (
+    BACKEND_AWS_IOT,
+    BACKEND_GIZWITS,
     CONF_API_ROOT,
     CONF_API_ROOT_EU,
     CONF_PASSWORD,
@@ -40,13 +42,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up bestway from a config entry."""
 
     # Detect backend (default to Gizwits for backwards compatibility)
-    backend = entry.data.get("backend", "gizwits")
+    backend = entry.data.get("backend", BACKEND_GIZWITS)
     _LOGGER.info("Setting up Bestway integration with %s backend", backend)
 
     session = async_get_clientsession(hass)
 
     # Branch based on backend
-    if backend == "aws_iot":
+    if backend == BACKEND_AWS_IOT:
         # AWS IoT V02 backend
         return await _async_setup_aws_iot(hass, entry, session)
     else:

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -8,7 +8,7 @@ from logging import getLogger
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .bestway.api import BestwayApi
@@ -38,6 +38,26 @@ _PLATFORMS: list[Platform] = [
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up bestway from a config entry."""
+
+    # Detect backend (default to Gizwits for backwards compatibility)
+    backend = entry.data.get("backend", "gizwits")
+    _LOGGER.info("Setting up Bestway integration with %s backend", backend)
+
+    session = async_get_clientsession(hass)
+
+    # Branch based on backend
+    if backend == "aws_iot":
+        # AWS IoT V02 backend
+        return await _async_setup_aws_iot(hass, entry, session)
+    else:
+        # Gizwits V01 backend (existing flow)
+        return await _async_setup_gizwits(hass, entry, session)
+
+
+async def _async_setup_gizwits(
+    hass: HomeAssistant, entry: ConfigEntry, session
+) -> bool:
+    """Set up Gizwits V01 backend (existing logic)."""
     username = str(entry.data.get(CONF_USERNAME))
     password = str(entry.data.get(CONF_PASSWORD))
     api_root = str(entry.data.get(CONF_API_ROOT))
@@ -46,8 +66,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if not isinstance(user_token_expiry, int):
         user_token_expiry = 0
-
-    session = async_get_clientsession(hass)
 
     # Check for an auth token
     # If we have one that expires within 30 days, refresh it
@@ -133,6 +151,99 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def _async_setup_aws_iot(
+    hass: HomeAssistant, entry: ConfigEntry, session
+) -> bool:
+    """Set up AWS IoT V02 backend."""
+    from .aws_iot.api import AwsIotApi, AwsIotAuthException
+    from .aws_iot.websocket import AwsIotWebSocket
+
+    visitor_id = entry.data["visitor_id"]
+    token = entry.data.get("token")
+    location = entry.data.get("location", "GB")
+    api_base = entry.data.get("api_base")  # Regional endpoint from config flow
+
+    # Fallback for existing configs without api_base
+    if not api_base:
+        from .aws_iot.api import API_ENDPOINTS
+        region = entry.data.get("region", "EU")
+        api_base = API_ENDPOINTS.get(region, API_ENDPOINTS["EU"])
+
+    _LOGGER.info("Initializing AWS IoT API for visitor %s (endpoint: %s)", visitor_id[:12], api_base)
+
+    # Initialize API
+    api = AwsIotApi(session, visitor_id, token, location, api_base)
+
+    # Authenticate if token missing or refresh if needed
+    if not token:
+        try:
+            token = await AwsIotApi.authenticate(session, visitor_id, location, api_base)
+            # Update entry with token
+            hass.config_entries.async_update_entry(
+                entry, data={**entry.data, "token": token}
+            )
+            api._token = token
+        except AwsIotAuthException as ex:
+            _LOGGER.error("AWS IoT authentication failed: %s", ex)
+            raise ConfigEntryAuthFailed from ex
+
+    # Initialize coordinator
+    coordinator = BestwayUpdateCoordinator(hass, entry, api)
+    await coordinator.async_config_entry_first_refresh()
+
+    # Initialize per-device WebSockets
+    websockets = []
+    if api.devices:
+        for device_id, device in api.devices.items():
+            try:
+                # Token refresh callback
+                async def token_refresh_callback():
+                    new_token = await AwsIotApi.authenticate(session, visitor_id, location, api_base)
+                    api._token = new_token
+                    hass.config_entries.async_update_entry(
+                        entry, data={**entry.data, "token": new_token}
+                    )
+                    return new_token
+
+                ws = AwsIotWebSocket(
+                    device_id=device_id,
+                    service_region=device.ws_host,  # Region stored in ws_host
+                    token=token,
+                    update_callback=coordinator.handle_websocket_update,
+                    disconnect_callback=coordinator.handle_websocket_disconnect,
+                    token_refresh_callback=token_refresh_callback,
+                )
+
+                # Connect in background
+                hass.async_create_task(ws.connect())
+                websockets.append(ws)
+
+                _LOGGER.info(
+                    "WebSocket initialized for device %s (region: %s)",
+                    device_id[:12],
+                    device.ws_host,
+                )
+
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.warning(
+                    "Failed to setup WebSocket for device %s: %s", device_id[:12], ex
+                )
+
+        # Reduce polling with WebSocket active
+        coordinator.set_websocket_active()
+    else:
+        _LOGGER.warning("No devices found, WebSocket not initialized")
+
+    # Store WebSockets list on coordinator
+    coordinator.websockets = websockets
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    return True
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok: bool = await hass.config_entries.async_unload_platforms(
@@ -141,10 +252,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
 
-        # Cleanup WebSocket connection
+        # Cleanup WebSocket connection(s)
+        # Gizwits: Single websocket
         if hasattr(coordinator, "websocket") and coordinator.websocket:
             await coordinator.websocket.disconnect()
-            _LOGGER.info("WebSocket client disconnected")
+            _LOGGER.info("Gizwits WebSocket disconnected")
+
+        # AWS IoT: Multiple websockets (list)
+        if hasattr(coordinator, "websockets") and coordinator.websockets:
+            for ws in coordinator.websockets:
+                try:
+                    await ws.disconnect()
+                except Exception as ex:
+                    _LOGGER.warning("Error disconnecting WebSocket: %s", ex)
+            _LOGGER.info("AWS IoT WebSockets disconnected (%d devices)", len(coordinator.websockets))
 
     return unload_ok
 

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from logging import getLogger
 
+from aiohttp import ClientSession
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -57,7 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _async_setup_gizwits(
-    hass: HomeAssistant, entry: ConfigEntry, session
+    hass: HomeAssistant, entry: ConfigEntry, session: ClientSession
 ) -> bool:
     """Set up Gizwits V01 backend (existing logic)."""
     username = str(entry.data.get(CONF_USERNAME))
@@ -154,7 +155,7 @@ async def _async_setup_gizwits(
 
 
 async def _async_setup_aws_iot(
-    hass: HomeAssistant, entry: ConfigEntry, session
+    hass: HomeAssistant, entry: ConfigEntry, session: ClientSession
 ) -> bool:
     """Set up AWS IoT V02 backend."""
     from .aws_iot.api import AwsIotApi, AwsIotAuthException
@@ -168,10 +169,15 @@ async def _async_setup_aws_iot(
     # Fallback for existing configs without api_base
     if not api_base:
         from .aws_iot.api import API_ENDPOINTS
+
         region = entry.data.get("region", "EU")
         api_base = API_ENDPOINTS.get(region, API_ENDPOINTS["EU"])
 
-    _LOGGER.info("Initializing AWS IoT API for visitor %s (endpoint: %s)", visitor_id[:12], api_base)
+    _LOGGER.info(
+        "Initializing AWS IoT API for visitor %s (endpoint: %s)",
+        visitor_id[:12],
+        api_base,
+    )
 
     # Initialize API
     api = AwsIotApi(session, visitor_id, token, location, api_base)
@@ -179,7 +185,9 @@ async def _async_setup_aws_iot(
     # Authenticate if token missing or refresh if needed
     if not token:
         try:
-            token = await AwsIotApi.authenticate(session, visitor_id, location, api_base)
+            token = await AwsIotApi.authenticate(
+                session, visitor_id, location, api_base
+            )
             # Update entry with token
             hass.config_entries.async_update_entry(
                 entry, data={**entry.data, "token": token}
@@ -199,8 +207,10 @@ async def _async_setup_aws_iot(
         for device_id, device in api.devices.items():
             try:
                 # Token refresh callback
-                async def token_refresh_callback():
-                    new_token = await AwsIotApi.authenticate(session, visitor_id, location, api_base)
+                async def token_refresh_callback() -> str:
+                    new_token = await AwsIotApi.authenticate(
+                        session, visitor_id, location, api_base
+                    )
                     api._token = new_token
                     hass.config_entries.async_update_entry(
                         entry, data={**entry.data, "token": new_token}
@@ -256,18 +266,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # Cleanup WebSocket connection(s)
         # Gizwits: Single websocket
-        if hasattr(coordinator, "websocket") and coordinator.websocket:
+        if coordinator.websocket:
             await coordinator.websocket.disconnect()
             _LOGGER.info("Gizwits WebSocket disconnected")
 
         # AWS IoT: Multiple websockets (list)
-        if hasattr(coordinator, "websockets") and coordinator.websockets:
+        if coordinator.websockets:
             for ws in coordinator.websockets:
                 try:
                     await ws.disconnect()
                 except Exception as ex:
                     _LOGGER.warning("Error disconnecting WebSocket: %s", ex)
-            _LOGGER.info("AWS IoT WebSockets disconnected (%d devices)", len(coordinator.websockets))
+            _LOGGER.info(
+                "AWS IoT WebSockets disconnected (%d devices)",
+                len(coordinator.websockets),
+            )
 
     return unload_ok
 

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -30,6 +30,7 @@ from ..bestway.model import (
     BubblesLevel,
     HYDROJET_BUBBLES_MAP,
 )
+from ..const import BACKEND_AWS_IOT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -135,32 +136,55 @@ class AwsIotApi:
         else:
             wave_normalized = wave_state  # 0 and 100 are same in both
 
-        return {
-            # Version fields (diagnostic)
-            "wifi_version": device_state.get("wifivertion"),  # API typo
-            "ota_status": device_state.get("otastatus"),
-            "mcu_version": device_state.get("mcuversion"),
-            "trd_version": device_state.get("trdversion"),
-            "connect_type": device_state.get("ConnectType"),
-            # Control state - use exact V01 field names!
-            "power": bool(power_state == 1) if power_state is not None else None,
-            "heat": device_state.get("heater_state"),  # Keep numeric (0/3/4)
-            "wave": wave_normalized,  # Normalize for select entity
-            "filter": device_state.get("filter_state"),  # Keep numeric (0/1/2)
-            "jet": bool(device_state.get("hydrojet_state") == 1) if device_state.get("hydrojet_state") is not None else None,
-            "locked": device_state.get("locked"),
-            # Temperature - use V01 field names (capital T!)
-            "Tnow": device_state.get("water_temperature"),
-            "Tset": device_state.get("temperature_setting"),
-            "Tunit": temperature_unit,  # 0=°F, 1=°C (keep numeric)
-            # Errors
-            "warning": 0 if warning == "" else warning,
-            "error": 0 if error_code == "" else error_code,
-            # Status
-            "is_online": device_state.get("is_online"),
-            # V01-specific fields for compatibility
-            "word3": 0,  # Target reached flag (unknown for V02)
-        }
+        # Build normalized dict, only including fields with actual values
+        # This prevents None values from overwriting existing data during merges
+        normalized = {}
+
+        # Version fields (diagnostic) - only if present
+        if "wifivertion" in device_state:
+            normalized["wifi_version"] = device_state["wifivertion"]
+        if "otastatus" in device_state:
+            normalized["ota_status"] = device_state["otastatus"]
+        if "mcuversion" in device_state:
+            normalized["mcu_version"] = device_state["mcuversion"]
+        if "trdversion" in device_state:
+            normalized["trd_version"] = device_state["trdversion"]
+        if "ConnectType" in device_state:
+            normalized["connect_type"] = device_state["ConnectType"]
+
+        # Control state - use exact V01 field names!
+        if power_state is not None:
+            normalized["power"] = bool(power_state == 1)
+        if device_state.get("heater_state") is not None:
+            normalized["heat"] = device_state["heater_state"]
+        if wave_state is not None:
+            normalized["wave"] = wave_normalized
+        if device_state.get("filter_state") is not None:
+            normalized["filter"] = device_state["filter_state"]
+        if device_state.get("hydrojet_state") is not None:
+            normalized["jet"] = bool(device_state["hydrojet_state"] == 1)
+        if device_state.get("locked") is not None:
+            normalized["locked"] = device_state["locked"]
+
+        # Temperature - use V01 field names (capital T!)
+        if device_state.get("water_temperature") is not None:
+            normalized["Tnow"] = device_state["water_temperature"]
+        if device_state.get("temperature_setting") is not None:
+            normalized["Tset"] = device_state["temperature_setting"]
+        normalized["Tunit"] = temperature_unit  # Always include
+
+        # Errors
+        normalized["warning"] = 0 if warning == "" else warning
+        normalized["error"] = 0 if error_code == "" else error_code
+
+        # Status
+        if device_state.get("is_online") is not None:
+            normalized["is_online"] = device_state["is_online"]
+
+        # V01-specific fields for compatibility
+        normalized["word3"] = 0  # Target reached flag (unknown for V02)
+
+        return normalized
 
     @staticmethod
     async def authenticate(
@@ -418,7 +442,7 @@ class AwsIotApi:
         1. GET /api/enduser/homes → list of homes
         2. For each home: GET /api/enduser/home/rooms?home_id=X → rooms
         3. For each room: GET /api/enduser/home/room/devices?room_id=Y → devices
-        4. Create BestwayDevice for each device with backend="aws_iot"
+        4. Create BestwayDevice for each device with backend=BACKEND_AWS_IOT
 
         Note: Device discovery is cached after first successful run.
         Devices are only re-discovered if device list is empty.
@@ -504,7 +528,7 @@ class AwsIotApi:
                 is_online=dev.get("is_online", True),
                 ws_host=dev.get("service_region", "eu-central-1"),  # Store region in ws_host
                 ws_port=443,  # AWS IoT WebSocket uses standard HTTPS port
-                backend="aws_iot",
+                backend=BACKEND_AWS_IOT,
                 product_id=product_id,  # NEW: Model ID for shadow fetch
                 product_series=product_series,  # NEW: Series for device_type
             )
@@ -567,8 +591,21 @@ class AwsIotApi:
                 else:
                     device_state = raw_data
 
+                _LOGGER.debug(
+                    "Raw device_state for %s has %d fields: %s",
+                    device_id[:12],
+                    len(device_state),
+                    list(device_state.keys()),
+                )
+
                 # Normalize AWS field names to Gizwits V01 equivalents
                 mapped = self.normalize_aws_state(device_state)
+
+                _LOGGER.debug(
+                    "After normalization: %d fields: %s",
+                    len(mapped),
+                    list(mapped.keys()),
+                )
 
                 # Update state cache
                 self._state_cache[device_id] = BestwayDeviceStatus(

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -156,6 +156,11 @@ class AwsIotApi:
         if power_state is not None:
             normalized["power"] = bool(power_state == 1)
         if device_state.get("heater_state") is not None:
+            # Heater state values (same for V01 and V02):
+            # 0 = OFF
+            # 1 = ON (heater enabled, starting to heat)
+            # 3 = HEATING (actively heating toward target)
+            # 4 = TARGET_REACHED (at target temperature, maintaining)
             normalized["heat"] = device_state["heater_state"]
         if wave_state is not None:
             normalized["wave"] = wave_normalized
@@ -783,8 +788,15 @@ class AwsIotApi:
         await self.set_device_state(device_id, {"hydrojet_state": 1 if state else 0})
 
     async def hydrojet_spa_set_heat(self, device_id: str, heat_state: int) -> None:
-        """Set heater state for Hydrojet spa (0=OFF, 3=ON)."""
-        await self.set_device_state(device_id, {"heater_state": heat_state})
+        """Set heater state for Hydrojet spa.
+
+        Climate entity sends: HydrojetHeat.OFF=0, HydrojetHeat.ON=3
+        V02 command expects: heater_state=0 (OFF) or 1 (ON)
+        Device will respond with: 0,1,3,4 based on heating progress
+        """
+        # Convert V01 enum value (0/3) to V02 command value (0/1)
+        value = 1 if heat_state == 3 else 0
+        await self.set_device_state(device_id, {"heater_state": value})
 
     async def hydrojet_spa_set_target_temp(
         self, device_id: str, temperature: int

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -1,0 +1,791 @@
+"""AWS IoT API client for V02 Bestway devices.
+
+This module implements the AWS IoT backend API client that matches the Gizwits
+BestwayApi interface, enabling seamless integration with the existing coordinator
+and entity infrastructure.
+
+Backend: AWS IoT (smarthub-eu.bestwaycorp.com)
+Apps: Bestway Smart Spa app
+Devices: V02 models (Airjet V02, Hydrojet V02, etc)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import secrets
+from time import time
+from typing import Any
+
+from aiohttp import ClientSession
+
+from .encryption import encrypt_command_payload
+from ..bestway.model import (
+    AIRJET_V01_BUBBLES_MAP,
+    BestwayDevice,
+    BestwayDeviceStatus,
+    BestwayDeviceType,
+    BubblesLevel,
+    HYDROJET_BUBBLES_MAP,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# AWS IoT API Constants
+DEFAULT_API_BASE = "https://smarthub-eu.bestwaycorp.com"  # EU endpoint
+APP_ID = "AhFLL54HnChhrxcl9ZUJL6QNfolTIB"
+APP_SECRET = "4ECvVs13enL5AiYSmscNjvlaisklQDz7vWPCCWXcEFjhWfTmLT"
+TIMEOUT = 10
+
+# Regional API endpoints (from ServiceConfig.java)
+API_ENDPOINTS = {
+    "EU": "https://smarthub-eu.bestwaycorp.com",
+    "US": "https://smarthub-us.bestwaycorp.com",
+    "CN": "https://smarthub.bestwaycorp.cn",  # Note: .cn domain!
+    # "DEV": "http://bestway.dev.mxchip.com.cn",  # Dev/Test only
+}
+
+
+class AwsIotException(Exception):
+    """Base exception for AWS IoT API operations."""
+
+
+class AwsIotAuthException(AwsIotException):
+    """Authentication error."""
+
+
+class AwsIotApi:
+    """AWS IoT API client matching Gizwits BestwayApi interface.
+
+    This client provides the same interface as Gizwits BestwayApi, enabling
+    drop-in replacement in the coordinator and entity infrastructure.
+
+    Key responsibilities:
+    - Device discovery via homes → rooms → devices
+    - State fetching with field normalization
+    - Control commands with encryption
+    - Token refresh handling
+    """
+
+    def __init__(
+        self,
+        session: ClientSession,
+        visitor_id: str,
+        token: str | None = None,
+        location: str = "GB",
+        api_base: str = DEFAULT_API_BASE,
+    ) -> None:
+        """Initialize AWS IoT API client.
+
+        Args:
+            session: aiohttp ClientSession for HTTP requests
+            visitor_id: Visitor ID from QR code or existing account
+            token: Authentication token (optional, will authenticate if None)
+            location: Location code (e.g., "GB", "US") for API routing
+            api_base: API endpoint base URL (defaults to EU endpoint)
+        """
+        self._session = session
+        self._visitor_id = visitor_id
+        self._token = token
+        self._location = location
+        self._api_base = api_base
+
+        # Device registry (matches Gizwits interface)
+        self.devices: dict[str, BestwayDevice] = {}
+
+        # State cache (matches Gizwits interface)
+        self._state_cache: dict[str, BestwayDeviceStatus] = {}
+
+    @staticmethod
+    def generate_visitor_id() -> str:
+        """Generate random visitor_id for new account.
+
+        Returns:
+            16-character hex visitor_id
+        """
+        return secrets.token_hex(8)  # 16 hex chars
+
+    @staticmethod
+    def normalize_aws_state(device_state: dict[str, Any]) -> dict[str, Any]:
+        """Normalize AWS IoT field names to Gizwits V01 equivalents.
+
+        This normalization allows existing V01 entities to work unchanged with V02 devices.
+        Used by both fetch_data() and WebSocket message processing.
+
+        Args:
+            device_state: Raw state from AWS IoT device shadow
+
+        Returns:
+            Dict with normalized Gizwits V01 field names
+        """
+        warning = device_state.get("warning")
+        error_code = device_state.get("error_code")
+        power_state = device_state.get("power_state")
+        filter_state = device_state.get("filter_state")
+        temperature_unit = device_state.get("temperature_unit", 1)
+        wave_state = device_state.get("wave_state", 0)
+
+        # V02 wave_state actual values: 0=OFF, 40=MEDIUM, 100=HIGH
+        # Map to V01 Airjet format (0/50/100) for AIRJET_V01_BUBBLES_MAP compatibility
+        # Note: Hydrojet uses 40 for MEDIUM, so no mapping needed there
+        if wave_state == 40:
+            wave_normalized = 50  # Map V02 MEDIUM (40) → V01 Airjet MEDIUM (50)
+        else:
+            wave_normalized = wave_state  # 0 and 100 are same in both
+
+        return {
+            # Version fields (diagnostic)
+            "wifi_version": device_state.get("wifivertion"),  # API typo
+            "ota_status": device_state.get("otastatus"),
+            "mcu_version": device_state.get("mcuversion"),
+            "trd_version": device_state.get("trdversion"),
+            "connect_type": device_state.get("ConnectType"),
+            # Control state - use exact V01 field names!
+            "power": bool(power_state == 1) if power_state is not None else None,
+            "heat": device_state.get("heater_state"),  # Keep numeric (0/3/4)
+            "wave": wave_normalized,  # Normalize for select entity
+            "filter": device_state.get("filter_state"),  # Keep numeric (0/1/2)
+            "jet": bool(device_state.get("hydrojet_state") == 1) if device_state.get("hydrojet_state") is not None else None,
+            "locked": device_state.get("locked"),
+            # Temperature - use V01 field names (capital T!)
+            "Tnow": device_state.get("water_temperature"),
+            "Tset": device_state.get("temperature_setting"),
+            "Tunit": temperature_unit,  # 0=°F, 1=°C (keep numeric)
+            # Errors
+            "warning": 0 if warning == "" else warning,
+            "error": 0 if error_code == "" else error_code,
+            # Status
+            "is_online": device_state.get("is_online"),
+            # V01-specific fields for compatibility
+            "word3": 0,  # Target reached flag (unknown for V02)
+        }
+
+    @staticmethod
+    async def authenticate(
+        session: ClientSession,
+        visitor_id: str,
+        location: str = "GB",
+        api_base: str = DEFAULT_API_BASE,
+    ) -> str:
+        """Authenticate visitor and get token.
+
+        EXACT copy of working implementation from New_bestway_spa/spa_api.py
+        Do NOT modify without testing against real API!
+
+        Args:
+            session: aiohttp ClientSession
+            visitor_id: Visitor ID from QR binding or existing account
+            location: Location code (e.g., "GB", "US")
+            api_base: API endpoint base URL (defaults to EU endpoint)
+
+        Returns:
+            Authentication token
+
+        Raises:
+            AwsIotAuthException: If authentication fails
+        """
+        import random
+        import string
+
+        # Generate nonce EXACTLY as reference (lowercase + digits, NOT hex!)
+        nonce = "".join(random.choices(string.ascii_lowercase + string.digits, k=32))
+        timestamp = str(int(time()))
+        signature_data = f"{APP_ID}{APP_SECRET}{nonce}{timestamp}"
+        sign = hashlib.md5(signature_data.encode()).hexdigest().upper()
+
+        push_type = "fcm"
+
+        # Payload field order EXACTLY as reference
+        payload = {
+            "app_id": APP_ID,
+            "brand": "",  # CRITICAL: Required by API
+            "lan_code": "en",
+            "location": location,
+            "marketing_notification": 0,  # CRITICAL: Required by API
+            "push_type": push_type,
+            "timezone": "GMT",
+            "visitor_id": visitor_id,
+            "registration_id": "",
+        }
+
+        # Add client_id conditionally (reference logic)
+        if push_type == "fcm":
+            client_id = secrets.token_urlsafe(11)[:15].replace("-", "").replace("_", "").lower()
+            payload["client_id"] = client_id
+
+        # Headers EXACTLY as reference
+        headers = {
+            "pushtype": push_type,
+            "appid": APP_ID,
+            "nonce": nonce,
+            "ts": timestamp,
+            "accept-language": "en",
+            "sign": sign,
+            "Authorization": "token",
+            "Host": "smarthub-eu.bestwaycorp.com",
+            "Connection": "Keep-Alive",
+            "User-Agent": "okhttp/4.9.0",
+            "Content-Type": "application/json; charset=UTF-8",
+        }
+
+        url = f"{api_base}/api/enduser/visitor"
+
+        _LOGGER.debug("Authenticating visitor %s", visitor_id[:12])
+        _LOGGER.debug("Payload: %s", payload)
+        _LOGGER.debug("Nonce in headers: %s", 'nonce' in headers)
+        _LOGGER.debug("Sign in headers: %s", 'sign' in headers)
+        _LOGGER.debug("All header keys: %s", list(headers.keys()))
+
+        async with asyncio.timeout(TIMEOUT):
+            async with session.post(url, headers=headers, json=payload, ssl=False) as resp:
+                data = await resp.json()
+                _LOGGER.debug("Auth response: %s", data)
+                _LOGGER.debug("Response status: %s", resp.status)
+                token = data.get("data", {}).get("token")
+
+                if not token:
+                    _LOGGER.error("No token in response. Full response: %s", data)
+                    raise AwsIotAuthException("No token in authentication response")
+
+                return token
+
+    @staticmethod
+    async def bind_qr_code(
+        session: ClientSession,
+        qr_code: str,
+        visitor_id: str,
+        token: str,
+        api_base: str = DEFAULT_API_BASE,
+    ) -> dict[str, Any] | None:
+        """Bind device to visitor account using QR code.
+
+        Args:
+            session: aiohttp ClientSession
+            qr_code: QR code from spa (must start with "RW_Share_")
+            visitor_id: Visitor ID for binding
+            token: Authentication token
+            api_base: API endpoint base URL (defaults to EU endpoint)
+
+        Returns:
+            Device info dict if successful, None otherwise
+
+        Raises:
+            AwsIotException: If binding fails
+        """
+        # Validate QR format
+        if not qr_code.startswith("RW_Share_"):
+            raise AwsIotException("Invalid QR code format")
+
+        # Generate signature
+        nonce = secrets.token_hex(16)
+        timestamp = str(int(time()))
+        signature_data = f"{APP_ID}{APP_SECRET}{nonce}{timestamp}"
+        sign = hashlib.md5(signature_data.encode()).hexdigest().upper()
+
+        payload = {
+            "vercode": qr_code,
+            "push_type": "android",  # Required for grant_device API
+        }
+
+        headers = {
+            "pushtype": "android",
+            "appid": APP_ID,
+            "nonce": nonce,
+            "ts": timestamp,
+            "sign": sign,
+            "Authorization": f"token {token}",  # "token" prefix required!
+            "Content-Type": "application/json; charset=UTF-8",
+        }
+
+        url = f"{api_base}/api/enduser/grant_device"
+
+        async with asyncio.timeout(TIMEOUT):
+            response = await session.post(url, headers=headers, json=payload, ssl=False)
+
+            if response.status in (400, 401, 4001, 4002):
+                raise AwsIotException("QR code invalid, expired, or already used")
+
+            response.raise_for_status()
+            data = await response.json()
+
+            return data.get("data")
+
+    def _generate_auth_headers(self) -> dict[str, str]:
+        """Generate authentication headers for API requests.
+
+        EXACT copy of reference implementation.
+
+        Returns:
+            Headers dict with signature and authentication
+        """
+        import random
+        import string
+
+        # Generate nonce EXACTLY as reference
+        nonce = "".join(random.choices(string.ascii_lowercase + string.digits, k=32))
+        timestamp = str(int(time()))
+        signature = hashlib.md5(f"{APP_ID}{APP_SECRET}{nonce}{timestamp}".encode()).hexdigest().upper()
+
+        # Headers EXACTLY as reference (order matters!)
+        return {
+            "pushtype": "fcm",
+            "appid": APP_ID,
+            "nonce": nonce,
+            "ts": timestamp,
+            "accept-language": "en",
+            "sign": signature,
+            "Authorization": f"token {self._token}",  # "token" not "Bearer"!
+            "Host": "smarthub-eu.bestwaycorp.com",
+            "Connection": "Keep-Alive",
+            "User-Agent": "okhttp/4.9.0",
+            "Content-Type": "application/json; charset=UTF-8",
+        }
+
+    async def _do_get(self, path: str) -> dict[str, Any]:
+        """Execute GET request with authentication.
+
+        Args:
+            path: API endpoint path
+
+        Returns:
+            Response JSON data
+
+        Raises:
+            AwsIotAuthException: On HTTP 401 (invalid token)
+            AwsIotException: On other errors
+        """
+        url = f"{self._api_base}{path}"
+        headers = self._generate_auth_headers()
+
+        _LOGGER.debug("GET %s", path)
+
+        async with asyncio.timeout(TIMEOUT):
+            async with self._session.get(url, headers=headers, ssl=False) as response:
+                data = await response.json()
+
+                # Check for errors
+                if response.status in (400, 401):
+                    raise AwsIotAuthException("Token expired or invalid")
+
+                if response.status != 200:
+                    raise AwsIotException(f"API error: {response.status}")
+
+                return data
+
+    async def _do_post(self, path: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Execute POST request with authentication.
+
+        Args:
+            path: API endpoint path
+            data: Request body data
+
+        Returns:
+            Response JSON data
+
+        Raises:
+            AwsIotAuthException: On HTTP 401 (invalid token)
+            AwsIotException: On other errors
+        """
+        url = f"{self._api_base}{path}"
+        headers = self._generate_auth_headers()
+
+        _LOGGER.debug("POST %s", path)
+
+        async with asyncio.timeout(TIMEOUT):
+            async with self._session.post(url, headers=headers, json=data, ssl=False) as response:
+                result = await response.json()
+
+                _LOGGER.debug("POST %s response (status=%d): %s", path, response.status, result)
+
+                # Check for errors
+                if response.status in (400, 401):
+                    raise AwsIotAuthException("Token expired or invalid")
+
+                if response.status != 200:
+                    raise AwsIotException(f"API error: {response.status}")
+
+                return result
+
+    async def refresh_bindings(self) -> None:
+        """Discover and store all devices under visitor account.
+
+        Implements the same interface as Gizwits BestwayApi.refresh_bindings().
+        Populates self.devices with all discovered devices.
+
+        Discovery flow:
+        1. GET /api/enduser/homes → list of homes
+        2. For each home: GET /api/enduser/home/rooms?home_id=X → rooms
+        3. For each room: GET /api/enduser/home/room/devices?room_id=Y → devices
+        4. Create BestwayDevice for each device with backend="aws_iot"
+
+        Note: Device discovery is cached after first successful run.
+        Devices are only re-discovered if device list is empty.
+        This reduces API load from N calls every 5min to N calls once per session.
+        """
+        # Skip discovery if we already have devices (cache)
+        if self.devices:
+            _LOGGER.debug("Using cached device list (%d devices)", len(self.devices))
+            return
+
+        _LOGGER.debug("Discovering devices for visitor %s", self._visitor_id[:12])
+
+        discovered_devices = []
+
+        # Step 1: Get homes
+        homes_response = await self._do_get("/api/enduser/homes")
+        _LOGGER.debug("Homes API response: %s", homes_response)
+
+        # Check for API error code
+        if homes_response.get("code") != 0:
+            _LOGGER.error("Failed to get homes: %s", homes_response.get("message"))
+            return
+
+        homes = homes_response.get("data", {}).get("list", [])
+        _LOGGER.debug("Found %d homes", len(homes))
+
+        # Step 2 & 3: Get rooms and devices for each home
+        for home in homes:
+            home_id = home.get("id")  # EXACT reference field name
+            home_name = home.get("name", "Unknown")
+            _LOGGER.debug("Processing home: %s (id=%s)", home_name, home_id)
+
+            # Get rooms in this home
+            rooms_response = await self._do_get(
+                f"/api/enduser/home/rooms?home_id={home_id}"
+            )
+
+            # Check for API error
+            if rooms_response.get("code") != 0:
+                _LOGGER.warning("Failed to get rooms for home %s", home_id)
+                continue
+
+            rooms = rooms_response.get("data", {}).get("list", [])
+            _LOGGER.debug("Found %d room(s) in home %s", len(rooms), home_name)
+
+            for room in rooms:
+                room_id = room.get("id")  # EXACT reference field name
+                room_name = room.get("name", "Unknown")
+                _LOGGER.debug("Processing room: %s (id=%s)", room_name, room_id)
+
+                # Get devices in this room
+                devices_response = await self._do_get(
+                    f"/api/enduser/home/room/devices?room_id={room_id}"
+                )
+
+                # Check for API error
+                if devices_response.get("code") != 0:
+                    _LOGGER.warning("Failed to get devices for room %s", room_id)
+                    continue
+
+                devices = devices_response.get("data", {}).get("list", [])
+                _LOGGER.debug("Found %d device(s) in room %s", len(devices), room_name)
+                discovered_devices.extend(devices)
+
+        _LOGGER.info("Discovered %d devices", len(discovered_devices))
+
+        # Convert to BestwayDevice format
+        self.devices = {}
+        for dev in discovered_devices:
+            device_id = dev["device_id"]
+            product_id = dev.get("product_id", "UNKNOWN").strip()  # e.g., "T53NN8"
+            product_series = dev.get("product_series", "AIRJET").strip()  # e.g., "AIRJET" (strip whitespace!)
+
+            device = BestwayDevice(
+                protocol_version=2,  # V02 protocol
+                device_id=device_id,
+                product_name=product_series,  # For backwards compat (V02 uses series as name)
+                alias=dev.get("device_alias") or dev.get("device_name") or device_id[:12],
+                mcu_soft_version=dev.get("mcu_version", "unknown"),
+                mcu_hard_version=dev.get("mcu_version", "unknown"),
+                wifi_soft_version=dev.get("wifi_version", "unknown"),
+                wifi_hard_version=dev.get("wifi_version", "unknown"),
+                is_online=dev.get("is_online", True),
+                ws_host=dev.get("service_region", "eu-central-1"),  # Store region in ws_host
+                ws_port=443,  # AWS IoT WebSocket uses standard HTTPS port
+                backend="aws_iot",
+                product_id=product_id,  # NEW: Model ID for shadow fetch
+                product_series=product_series,  # NEW: Series for device_type
+            )
+
+            _LOGGER.info(
+                "Device %s: product_id=%s, product_series=%s, device_type=%s",
+                device.alias,
+                product_id,
+                product_series,
+                device.device_type,
+            )
+
+            self.devices[device_id] = device
+
+    async def fetch_data(self) -> Any:  # Returns BestwayApiResults
+        """Fetch latest state for all devices.
+
+        Implements the same interface as Gizwits BestwayApi.fetch_data().
+
+        For each device:
+        1. POST /api/device/thing_shadow/ with device_id + product_id
+        2. Parse shadow.state.reported or shadow.state.desired
+        3. Return raw AWS field names (water_temperature, temperature_setting, etc.)
+        4. Store in state cache
+
+        Returns:
+            BestwayApiResults with devices dict
+        """
+        # Import here to avoid circular dependency
+        from ..bestway.api import BestwayApiResults
+
+        for device_id in self.devices:
+            try:
+                # Get device metadata
+                device = self.devices[device_id]
+
+                # Build payload with device_id and product_id (EXACT reference format)
+                payload = {
+                    "device_id": device_id,
+                    "product_id": device.product_id or device.product_name,  # Model ID (e.g., "T53NN8")
+                }
+
+                # Fetch device shadow using POST (EXACT reference endpoint!)
+                shadow_response = await self._do_post(
+                    "/api/device/thing_shadow/",
+                    payload
+                )
+
+                # Extract state (EXACT reference logic!)
+                raw_data = shadow_response.get("data", {})
+
+                # Try reported first, then desired, then raw state (reference logic)
+                if "state" in raw_data:
+                    if "reported" in raw_data["state"]:
+                        device_state = raw_data["state"]["reported"]
+                    elif "desired" in raw_data["state"]:
+                        device_state = raw_data["state"]["desired"]
+                    else:
+                        device_state = raw_data["state"]
+                else:
+                    device_state = raw_data
+
+                # Normalize AWS field names to Gizwits V01 equivalents
+                mapped = self.normalize_aws_state(device_state)
+
+                # Update state cache
+                self._state_cache[device_id] = BestwayDeviceStatus(
+                    timestamp=int(time()), attrs=mapped
+                )
+
+                _LOGGER.debug(
+                    "Fetched state for device %s: %d fields",
+                    device_id[:12],
+                    len(mapped),
+                )
+
+            except Exception as err:
+                _LOGGER.warning("Failed to fetch state for device %s: %s", device_id[:12], err)
+                # Keep existing cache or mark offline
+                if device_id not in self._state_cache:
+                    self._state_cache[device_id] = BestwayDeviceStatus(
+                        timestamp=int(time()), attrs={}
+                    )
+
+        return BestwayApiResults(devices=self._state_cache)
+
+    async def set_device_state(
+        self, device_id: str, state_updates: dict[str, Any]
+    ) -> bool:
+        """Set device state fields using shadow update.
+
+        Args:
+            device_id: Target device ID
+            state_updates: Dict of AWS field names and values
+                         (e.g., "power_state", "heater_state", "temperature_setting")
+
+        Returns:
+            True if successful
+
+        Example:
+            await api.set_device_state("abc123", {"power_state": 1, "heater_state": 3})
+        """
+        # Convert bool/enum to int (commands use AWS field names!)
+        aws_updates = {}
+        for key, value in state_updates.items():
+            if isinstance(value, bool):
+                value = 1 if value else 0
+            elif hasattr(value, 'value'):  # Extract from IntEnum
+                value = int(value.value)
+            elif not isinstance(value, int):
+                value = int(value)
+            aws_updates[key] = value
+
+        if not aws_updates:
+            return False
+
+        # Get fresh signature for encryption
+        import json as json_module
+
+        headers = self._generate_auth_headers()
+        sign = headers["sign"]
+
+        _LOGGER.debug("Using sign for encryption: %s", sign[:16])
+
+        # Build shadow payload using AWS field names (nested JSON string format!)
+        shadow_payload = {"state": {"desired": aws_updates}}
+        desired_json_string = json_module.dumps(shadow_payload, separators=(",", ":"))
+
+        # Build command payload
+        device = self.devices[device_id]
+        command_payload = {
+            "device_id": device_id,
+            "product_id": device.product_id,  # Use exact product_id
+            "desired": desired_json_string,  # JSON string!
+        }
+
+        # Serialize to JSON string
+        plaintext = json_module.dumps(command_payload, separators=(",", ":"))
+
+        _LOGGER.info("v2 command: fields=%s, product_id=%s", aws_updates, device.product_id)
+        _LOGGER.debug("v2 plaintext: %s", plaintext)
+
+        # Encrypt plaintext string (EXACT reference signature!)
+        encrypted_payload = encrypt_command_payload(sign, APP_SECRET, plaintext)
+
+        # Send command - use SAME headers that contain the sign we encrypted with!
+        body = {"encrypted_data": encrypted_payload}
+
+        # Try v2 API first (encrypted) - pass headers explicitly to ensure sign matches
+        try:
+            async with self._session.post(
+                f"{self._api_base}/api/v2/device/command",
+                headers=headers,  # Use SAME headers with matching sign!
+                json=body,
+                ssl=False
+            ) as response:
+                result = await response.json()
+                _LOGGER.debug("v2 POST response (status=%d): %s", response.status, result)
+
+                if result.get("code") == 0:
+                    _LOGGER.info("✓ v2 API command sent to device %s", device_id[:12])
+                    return True
+                else:
+                    _LOGGER.warning(
+                        "v2 API returned error code %s, falling back to v1",
+                        result.get("code"),
+                    )
+
+        except Exception as err:
+            _LOGGER.warning("v2 API error (%s), falling back to v1", str(err))
+
+        # v1 API fallback (unencrypted, reference implementation)
+        _LOGGER.info("v1 fallback: using AWS field names")
+
+        device = self.devices[device_id]
+        v1_payload = {
+            "device_id": device_id,
+            "product_id": device.product_id,
+            "desired": {"state": {"desired": aws_updates}},  # AWS field names!
+        }
+
+        _LOGGER.debug("v1 payload: %s", v1_payload)
+
+        try:
+            response = await self._do_post("/api/device/command/", v1_payload)
+
+            if response.get("code") == 0:
+                _LOGGER.info("✓ v1 API command sent to device %s", device_id[:12])
+                return True
+            else:
+                _LOGGER.error("v1 API also failed with code %s", response.get("code"))
+                return False
+
+        except Exception as err:
+            _LOGGER.error("Failed to send command to device %s: %s", device_id[:12], err)
+            return False
+
+    # Convenience methods matching Gizwits interface (with AWS field name translation)
+    async def airjet_spa_set_power(self, device_id: str, state: bool) -> None:
+        """Set power state for Airjet spa."""
+        await self.set_device_state(device_id, {"power_state": 1 if state else 0})
+
+    async def airjet_spa_set_filter(self, device_id: str, state: bool) -> None:
+        """Set filter state for Airjet spa."""
+        await self.set_device_state(device_id, {"filter_state": 1 if state else 0})
+
+    async def airjet_spa_set_bubbles(self, device_id: str, state: bool) -> None:
+        """Set bubbles state for Airjet spa."""
+        await self.set_device_state(device_id, {"wave_state": 100 if state else 0})
+
+    async def airjet_spa_set_locked(self, device_id: str, state: bool) -> None:
+        """Set locked state for Airjet spa."""
+        await self.set_device_state(device_id, {"locked": 1 if state else 0})
+
+    async def airjet_spa_set_target_temp(
+        self, device_id: str, temperature: int
+    ) -> None:
+        """Set target temperature for Airjet spa."""
+        await self.set_device_state(device_id, {"temperature_setting": temperature})
+
+    async def hydrojet_spa_set_power(self, device_id: str, state: bool) -> None:
+        """Set power state for Hydrojet spa."""
+        await self.set_device_state(device_id, {"power_state": 1 if state else 0})
+
+    async def hydrojet_spa_set_filter(self, device_id: str, filter_state: int) -> None:
+        """Set filter state for Hydrojet spa.
+
+        V02 uses: 0=OFF, 1=ON (not 2!)
+        """
+        # Extract value from enum if needed
+        value = filter_state.value if hasattr(filter_state, 'value') else filter_state
+        # V02 uses 1 for ON, not 2
+        if value == 2:
+            value = 1
+        await self.set_device_state(device_id, {"filter_state": value})
+
+    async def hydrojet_spa_set_jets(self, device_id: str, state: bool) -> None:
+        """Set jets state for Hydrojet spa."""
+        await self.set_device_state(device_id, {"hydrojet_state": 1 if state else 0})
+
+    async def hydrojet_spa_set_heat(self, device_id: str, heat_state: int) -> None:
+        """Set heater state for Hydrojet spa (0=OFF, 3=ON)."""
+        await self.set_device_state(device_id, {"heater_state": heat_state})
+
+    async def hydrojet_spa_set_target_temp(
+        self, device_id: str, temperature: int
+    ) -> None:
+        """Set target temperature for Hydrojet spa."""
+        await self.set_device_state(device_id, {"temperature_setting": temperature})
+
+    async def airjet_v01_spa_set_bubbles(
+        self, device_id: str, level: BubblesLevel
+    ) -> None:
+        """Set bubbles level for Airjet spa.
+
+        V02 device reports absolute values:
+        - OFF: wave_state=0
+        - MEDIUM: wave_state=40
+        - HIGH: wave_state=100
+
+        Physical button cycles: OFF → HIGH → MEDIUM → OFF
+        Try sending absolute values first (simplest approach).
+        """
+        # Map BubblesLevel enum to V02 wave_state values
+        value_map = {
+            BubblesLevel.OFF: 0,
+            BubblesLevel.MEDIUM: 40,  # V02 uses 40 not 50!
+            BubblesLevel.MAX: 100,
+        }
+
+        target_value = value_map.get(level)
+        if target_value is not None:
+            await self.set_device_state(device_id, {"wave_state": target_value})
+            _LOGGER.debug("Set bubbles to %s (wave_state=%d)", level.name, target_value)
+
+    async def hydrojet_spa_set_bubbles(
+        self, device_id: str, level: BubblesLevel
+    ) -> None:
+        """Set bubbles level for Hydrojet spa.
+
+        V02 uses same toggle approach as Airjet V02.
+        """
+        # V02 uses toggle approach (same as Airjet V02)
+        await self.airjet_v01_spa_set_bubbles(device_id, level)

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -176,11 +176,14 @@ class AwsIotApi:
             normalized["Tnow"] = device_state["water_temperature"]
         if device_state.get("temperature_setting") is not None:
             normalized["Tset"] = device_state["temperature_setting"]
-        normalized["Tunit"] = temperature_unit  # Always include
+        if "temperature_unit" in device_state:
+            normalized["Tunit"] = temperature_unit
 
-        # Errors
-        normalized["warning"] = 0 if warning == "" else warning
-        normalized["error"] = 0 if error_code == "" else error_code
+        # Errors - only include if present to avoid overwriting during delta merges
+        if "warning" in device_state:
+            normalized["warning"] = 0 if warning == "" else warning
+        if "error_code" in device_state:
+            normalized["error"] = 0 if error_code == "" else error_code
 
         # Status
         if device_state.get("is_online") is not None:

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -490,7 +490,7 @@ class AwsIotApi:
         for dev in discovered_devices:
             device_id = dev["device_id"]
             product_id = dev.get("product_id", "UNKNOWN").strip()  # e.g., "T53NN8"
-            product_series = dev.get("product_series", "AIRJET").strip()  # e.g., "AIRJET" (strip whitespace!)
+            product_series = dev.get("product_series", "AIRJET").strip().replace(" ", "_")  # Normalize spaces to underscores
 
             device = BestwayDevice(
                 protocol_version=2,  # V02 protocol

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
 import logging
 import secrets
 from time import time
@@ -23,12 +22,9 @@ from aiohttp import ClientSession
 
 from .encryption import encrypt_command_payload
 from ..bestway.model import (
-    AIRJET_V01_BUBBLES_MAP,
     BestwayDevice,
     BestwayDeviceStatus,
-    BestwayDeviceType,
     BubblesLevel,
-    HYDROJET_BUBBLES_MAP,
 )
 from ..const import BACKEND_AWS_IOT
 
@@ -124,7 +120,6 @@ class AwsIotApi:
         warning = device_state.get("warning")
         error_code = device_state.get("error_code")
         power_state = device_state.get("power_state")
-        filter_state = device_state.get("filter_state")
         temperature_unit = device_state.get("temperature_unit", 1)
         wave_state = device_state.get("wave_state", 0)
 
@@ -244,7 +239,9 @@ class AwsIotApi:
 
         # Add client_id conditionally (reference logic)
         if push_type == "fcm":
-            client_id = secrets.token_urlsafe(11)[:15].replace("-", "").replace("_", "").lower()
+            client_id = (
+                secrets.token_urlsafe(11)[:15].replace("-", "").replace("_", "").lower()
+            )
             payload["client_id"] = client_id
 
         # Headers EXACTLY as reference
@@ -266,12 +263,14 @@ class AwsIotApi:
 
         _LOGGER.debug("Authenticating visitor %s", visitor_id[:12])
         _LOGGER.debug("Payload: %s", payload)
-        _LOGGER.debug("Nonce in headers: %s", 'nonce' in headers)
-        _LOGGER.debug("Sign in headers: %s", 'sign' in headers)
+        _LOGGER.debug("Nonce in headers: %s", "nonce" in headers)
+        _LOGGER.debug("Sign in headers: %s", "sign" in headers)
         _LOGGER.debug("All header keys: %s", list(headers.keys()))
 
         async with asyncio.timeout(TIMEOUT):
-            async with session.post(url, headers=headers, json=payload, ssl=False) as resp:
+            async with session.post(
+                url, headers=headers, json=payload, ssl=False
+            ) as resp:
                 data = await resp.json()
                 _LOGGER.debug("Auth response: %s", data)
                 _LOGGER.debug("Response status: %s", resp.status)
@@ -281,7 +280,7 @@ class AwsIotApi:
                     _LOGGER.error("No token in response. Full response: %s", data)
                     raise AwsIotAuthException("No token in authentication response")
 
-                return token
+                return str(token)
 
     @staticmethod
     async def bind_qr_code(
@@ -342,7 +341,8 @@ class AwsIotApi:
             response.raise_for_status()
             data = await response.json()
 
-            return data.get("data")
+            result = data.get("data")
+            return dict(result) if result else None
 
     def _generate_auth_headers(self) -> dict[str, str]:
         """Generate authentication headers for API requests.
@@ -358,7 +358,11 @@ class AwsIotApi:
         # Generate nonce EXACTLY as reference
         nonce = "".join(random.choices(string.ascii_lowercase + string.digits, k=32))
         timestamp = str(int(time()))
-        signature = hashlib.md5(f"{APP_ID}{APP_SECRET}{nonce}{timestamp}".encode()).hexdigest().upper()
+        signature = (
+            hashlib.md5(f"{APP_ID}{APP_SECRET}{nonce}{timestamp}".encode())
+            .hexdigest()
+            .upper()
+        )
 
         # Headers EXACTLY as reference (order matters!)
         return {
@@ -404,7 +408,7 @@ class AwsIotApi:
                 if response.status != 200:
                     raise AwsIotException(f"API error: {response.status}")
 
-                return data
+                return dict(data)
 
     async def _do_post(self, path: str, data: dict[str, Any]) -> dict[str, Any]:
         """Execute POST request with authentication.
@@ -426,10 +430,14 @@ class AwsIotApi:
         _LOGGER.debug("POST %s", path)
 
         async with asyncio.timeout(TIMEOUT):
-            async with self._session.post(url, headers=headers, json=data, ssl=False) as response:
+            async with self._session.post(
+                url, headers=headers, json=data, ssl=False
+            ) as response:
                 result = await response.json()
 
-                _LOGGER.debug("POST %s response (status=%d): %s", path, response.status, result)
+                _LOGGER.debug(
+                    "POST %s response (status=%d): %s", path, response.status, result
+                )
 
                 # Check for errors
                 if response.status in (400, 401):
@@ -438,7 +446,7 @@ class AwsIotApi:
                 if response.status != 200:
                     raise AwsIotException(f"API error: {response.status}")
 
-                return result
+                return dict(result)
 
     async def refresh_bindings(self) -> None:
         """Discover and store all devices under visitor account.
@@ -522,19 +530,25 @@ class AwsIotApi:
         for dev in discovered_devices:
             device_id = dev["device_id"]
             product_id = dev.get("product_id", "UNKNOWN").strip()  # e.g., "T53NN8"
-            product_series = dev.get("product_series", "AIRJET").strip().replace(" ", "_")  # Normalize spaces to underscores
+            product_series = (
+                dev.get("product_series", "AIRJET").strip().replace(" ", "_")
+            )  # Normalize spaces to underscores
 
             device = BestwayDevice(
                 protocol_version=2,  # V02 protocol
                 device_id=device_id,
                 product_name=product_series,  # For backwards compat (V02 uses series as name)
-                alias=dev.get("device_alias") or dev.get("device_name") or device_id[:12],
+                alias=dev.get("device_alias")
+                or dev.get("device_name")
+                or device_id[:12],
                 mcu_soft_version=dev.get("mcu_version", "unknown"),
                 mcu_hard_version=dev.get("mcu_version", "unknown"),
                 wifi_soft_version=dev.get("wifi_version", "unknown"),
                 wifi_hard_version=dev.get("wifi_version", "unknown"),
                 is_online=dev.get("is_online", True),
-                ws_host=dev.get("service_region", "eu-central-1"),  # Store region in ws_host
+                ws_host=dev.get(
+                    "service_region", "eu-central-1"
+                ),  # Store region in ws_host
                 ws_port=443,  # AWS IoT WebSocket uses standard HTTPS port
                 backend=BACKEND_AWS_IOT,
                 product_id=product_id,  # NEW: Model ID for shadow fetch
@@ -576,13 +590,13 @@ class AwsIotApi:
                 # Build payload with device_id and product_id (EXACT reference format)
                 payload = {
                     "device_id": device_id,
-                    "product_id": device.product_id or device.product_name,  # Model ID (e.g., "T53NN8")
+                    "product_id": device.product_id
+                    or device.product_name,  # Model ID (e.g., "T53NN8")
                 }
 
                 # Fetch device shadow using POST (EXACT reference endpoint!)
                 shadow_response = await self._do_post(
-                    "/api/device/thing_shadow/",
-                    payload
+                    "/api/device/thing_shadow/", payload
                 )
 
                 # Extract state (EXACT reference logic!)
@@ -627,7 +641,9 @@ class AwsIotApi:
                 )
 
             except Exception as err:
-                _LOGGER.warning("Failed to fetch state for device %s: %s", device_id[:12], err)
+                _LOGGER.warning(
+                    "Failed to fetch state for device %s: %s", device_id[:12], err
+                )
                 # Keep existing cache or mark offline
                 if device_id not in self._state_cache:
                     self._state_cache[device_id] = BestwayDeviceStatus(
@@ -657,7 +673,7 @@ class AwsIotApi:
         for key, value in state_updates.items():
             if isinstance(value, bool):
                 value = 1 if value else 0
-            elif hasattr(value, 'value'):  # Extract from IntEnum
+            elif hasattr(value, "value"):  # Extract from IntEnum
                 value = int(value.value)
             elif not isinstance(value, int):
                 value = int(value)
@@ -689,7 +705,9 @@ class AwsIotApi:
         # Serialize to JSON string
         plaintext = json_module.dumps(command_payload, separators=(",", ":"))
 
-        _LOGGER.info("v2 command: fields=%s, product_id=%s", aws_updates, device.product_id)
+        _LOGGER.info(
+            "v2 command: fields=%s, product_id=%s", aws_updates, device.product_id
+        )
         _LOGGER.debug("v2 plaintext: %s", plaintext)
 
         # Encrypt plaintext string (EXACT reference signature!)
@@ -704,10 +722,12 @@ class AwsIotApi:
                 f"{self._api_base}/api/v2/device/command",
                 headers=headers,  # Use SAME headers with matching sign!
                 json=body,
-                ssl=False
+                ssl=False,
             ) as response:
                 result = await response.json()
-                _LOGGER.debug("v2 POST response (status=%d): %s", response.status, result)
+                _LOGGER.debug(
+                    "v2 POST response (status=%d): %s", response.status, result
+                )
 
                 if result.get("code") == 0:
                     _LOGGER.info("✓ v2 API command sent to device %s", device_id[:12])
@@ -734,17 +754,21 @@ class AwsIotApi:
         _LOGGER.debug("v1 payload: %s", v1_payload)
 
         try:
-            response = await self._do_post("/api/device/command/", v1_payload)
+            v1_result: dict[str, Any] = await self._do_post(
+                "/api/device/command/", v1_payload
+            )
 
-            if response.get("code") == 0:
+            if v1_result.get("code") == 0:
                 _LOGGER.info("✓ v1 API command sent to device %s", device_id[:12])
                 return True
             else:
-                _LOGGER.error("v1 API also failed with code %s", response.get("code"))
+                _LOGGER.error("v1 API also failed with code %s", v1_result.get("code"))
                 return False
 
         except Exception as err:
-            _LOGGER.error("Failed to send command to device %s: %s", device_id[:12], err)
+            _LOGGER.error(
+                "Failed to send command to device %s: %s", device_id[:12], err
+            )
             return False
 
     # Convenience methods matching Gizwits interface (with AWS field name translation)
@@ -759,6 +783,10 @@ class AwsIotApi:
     async def airjet_spa_set_bubbles(self, device_id: str, state: bool) -> None:
         """Set bubbles state for Airjet spa."""
         await self.set_device_state(device_id, {"wave_state": 100 if state else 0})
+
+    async def airjet_spa_set_heat(self, device_id: str, heat: bool) -> None:
+        """Set heater state for Airjet spa."""
+        await self.set_device_state(device_id, {"heater_state": 1 if heat else 0})
 
     async def airjet_spa_set_locked(self, device_id: str, state: bool) -> None:
         """Set locked state for Airjet spa."""
@@ -780,7 +808,7 @@ class AwsIotApi:
         V02 uses: 0=OFF, 1=ON (not 2!)
         """
         # Extract value from enum if needed
-        value = filter_state.value if hasattr(filter_state, 'value') else filter_state
+        value = filter_state.value if hasattr(filter_state, "value") else filter_state
         # V02 uses 1 for ON, not 2
         if value == 2:
             value = 1
@@ -841,3 +869,12 @@ class AwsIotApi:
         """
         # V02 uses toggle approach (same as Airjet V02)
         await self.airjet_v01_spa_set_bubbles(device_id, level)
+
+    # Pool filter methods (V01 only, not applicable to V02 spas)
+    async def pool_filter_set_power(self, device_id: str, power: bool) -> None:
+        """Not supported on V02 devices."""
+        raise NotImplementedError("Pool filter not supported on V02 devices")
+
+    async def pool_filter_set_time(self, device_id: str, hours: int) -> None:
+        """Not supported on V02 devices."""
+        raise NotImplementedError("Pool filter not supported on V02 devices")

--- a/custom_components/bestway/aws_iot/encryption.py
+++ b/custom_components/bestway/aws_iot/encryption.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
-from typing import TYPE_CHECKING
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,8 +59,7 @@ def encrypt_command_payload(sign: str, app_secret: str, plaintext: str) -> str:
     """
     if not HAS_PYCRYPTODOME:
         raise RuntimeError(
-            "pycryptodome not installed. "
-            "Install with: pip install pycryptodome>=3.20.0"
+            "pycryptodome not installed. Install with: pip install pycryptodome>=3.20.0"
         )
 
     # Key derivation: SHA-256(f"{sign},{app_secret}")[:32] as UTF-8 bytes
@@ -99,8 +97,7 @@ def decrypt_command_payload(sign: str, app_secret: str, ciphertext: str) -> str:
     """
     if not HAS_PYCRYPTODOME:
         raise RuntimeError(
-            "pycryptodome not installed. "
-            "Install with: pip install pycryptodome>=3.20.0"
+            "pycryptodome not installed. Install with: pip install pycryptodome>=3.20.0"
         )
 
     # Derive key same way as encryption
@@ -118,4 +115,4 @@ def decrypt_command_payload(sign: str, app_secret: str, ciphertext: str) -> str:
     padded_plaintext = cipher.decrypt(ct)
     plaintext = unpad(padded_plaintext, AES.block_size)
 
-    return plaintext.decode("utf-8")
+    return str(plaintext.decode("utf-8"))

--- a/custom_components/bestway/aws_iot/encryption.py
+++ b/custom_components/bestway/aws_iot/encryption.py
@@ -1,0 +1,121 @@
+"""AES-256-CBC encryption for AWS IoT backend commands.
+
+This module implements the Bestway-specific encryption algorithm discovered through
+reverse engineering of the official Bestway Smart Spa Android app.
+
+Algorithm Details:
+- Cipher: AES-256-CBC with PKCS7 padding
+- Key Derivation: SHA-256("{sign},{app_secret}")[:32] as UTF-8 bytes
+- IV: Fixed 16-byte array (hardcoded in official app)
+- Output: Base64(IV + ciphertext)
+
+Source: Decompiled from com/rongwei/library/utils/AESEncrypt.java
+Reference: layzspa-aws-iot/bestway_spa_client.py
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+_LOGGER = logging.getLogger(__name__)
+
+try:
+    from Crypto.Cipher import AES
+    from Crypto.Util.Padding import pad, unpad
+
+    HAS_PYCRYPTODOME = True
+except ImportError:
+    HAS_PYCRYPTODOME = False
+    _LOGGER.error(
+        "pycryptodome not installed - AWS IoT encryption unavailable. "
+        "Install with: pip install pycryptodome>=3.20.0"
+    )
+
+# Fixed IV from decompiled APK (never changes)
+# Source: AESEncrypt.java in com.rongwei.library.utils
+FIXED_IV = bytes(
+    [56, 110, 58, 168, 76, 255, 94, 159, 237, 215, 171, 181, 150, 40, 74, 166]
+)
+
+
+def encrypt_command_payload(sign: str, app_secret: str, plaintext: str) -> str:
+    """Encrypt command payload using Bestway's AES-256-CBC scheme.
+
+    EXACT copy of working implementation from New_bestway_spa/encryption.py
+    Signature: (sign, app_secret, plaintext_string) - NOT (data, sign, app_secret)!
+
+    Args:
+        sign: MD5 signature from current request (uppercase hex)
+        app_secret: APP_SECRET constant (same for all users, from APK)
+        plaintext: Command payload as JSON string (already serialized!)
+
+    Returns:
+        Base64-encoded encrypted payload: Base64(IV + ciphertext)
+
+    Raises:
+        RuntimeError: If pycryptodome is not installed
+    """
+    if not HAS_PYCRYPTODOME:
+        raise RuntimeError(
+            "pycryptodome not installed. "
+            "Install with: pip install pycryptodome>=3.20.0"
+        )
+
+    # Key derivation: SHA-256(f"{sign},{app_secret}")[:32] as UTF-8 bytes
+    key_material = f"{sign},{app_secret}".encode("utf-8")
+    key_hex = hashlib.sha256(key_material).hexdigest()[:32]
+    key = key_hex.encode("utf-8")  # 32 bytes
+
+    # Encrypt plaintext string with AES-256-CBC
+    cipher = AES.new(key, AES.MODE_CBC, FIXED_IV)
+    padded = pad(plaintext.encode("utf-8"), AES.block_size)
+    ciphertext = cipher.encrypt(padded)
+
+    # Return Base64(IV + ciphertext)
+    result = base64.b64encode(FIXED_IV + ciphertext).decode("utf-8")
+
+    _LOGGER.debug("Encrypted payload (first 20 chars): %s...", result[:20])
+    return result
+
+
+def decrypt_command_payload(sign: str, app_secret: str, ciphertext: str) -> str:
+    """Decrypt command payload (inverse of encrypt_command_payload).
+
+    EXACT copy of reference signature and behavior.
+
+    Args:
+        sign: Same MD5 signature used for encryption
+        app_secret: Same APP_SECRET constant
+        ciphertext: Base64-encoded encrypted data
+
+    Returns:
+        Decrypted plaintext string
+
+    Raises:
+        RuntimeError: If pycryptodome is not installed
+    """
+    if not HAS_PYCRYPTODOME:
+        raise RuntimeError(
+            "pycryptodome not installed. "
+            "Install with: pip install pycryptodome>=3.20.0"
+        )
+
+    # Derive key same way as encryption
+    key_material = f"{sign},{app_secret}".encode("utf-8")
+    key_hex = hashlib.sha256(key_material).hexdigest()[:32]
+    key = key_hex.encode("utf-8")
+
+    # Decode base64 and extract IV + ciphertext
+    data = base64.b64decode(ciphertext)
+    iv = data[:16]
+    ct = data[16:]
+
+    # Decrypt
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    padded_plaintext = cipher.decrypt(ct)
+    plaintext = unpad(padded_plaintext, AES.block_size)
+
+    return plaintext.decode("utf-8")

--- a/custom_components/bestway/aws_iot/websocket.py
+++ b/custom_components/bestway/aws_iot/websocket.py
@@ -1,0 +1,313 @@
+"""AWS IoT WebSocket client for V02 device real-time updates.
+
+Provides near-instant state synchronization by connecting to regional AWS API Gateway
+endpoints and receiving device shadow delta updates from AWS IoT Core.
+
+Key differences from Gizwits WebSocket:
+- No login message (Authorization header authentication)
+- Per-device connection (one WebSocket per device)
+- Regional endpoints (eu-central-1, us-west-1, etc)
+- Shadow delta message format (not s2c_noti)
+- 30s heartbeat (not 180s)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Callable
+
+import websockets
+from websockets.client import ClientProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# Regional WebSocket endpoints (from official app ServiceConfig.java)
+ENDPOINTS = {
+    "eu-central-1": "wss://7lv67j5lbh.execute-api.eu-central-1.amazonaws.com/prod",
+    "us-west-1": "wss://9i661wi8f9.execute-api.us-west-1.amazonaws.com/prod",
+    "cn-north-1": "wss://fu9gsv4dxh.execute-api.cn-north-1.amazonaws.com.cn/prod",
+}
+
+# Reconnection delays (exponential backoff)
+RECONNECT_DELAYS = [3, 6, 12, 24, 48, 60]  # seconds
+
+
+class AwsIotWebSocketException(Exception):
+    """Base exception for AWS IoT WebSocket operations."""
+
+
+class AwsIotWebSocket:
+    """Per-device WebSocket client for AWS IoT shadow updates.
+
+    Each device requires its own WebSocket connection to receive real-time
+    state updates from AWS IoT device shadows. Implements automatic
+    reconnection and integrates with coordinator callbacks.
+    """
+
+    def __init__(
+        self,
+        device_id: str,
+        service_region: str,
+        token: str,
+        update_callback: Callable[[str, dict[str, Any]], None],
+        disconnect_callback: Callable[[], None] | None = None,
+        token_refresh_callback: Callable[[], str] | None = None,
+    ) -> None:
+        """Initialize per-device WebSocket client.
+
+        Args:
+            device_id: Device ID for shadow subscription
+            service_region: AWS region (e.g., "eu-central-1")
+            token: JWT authentication token
+            update_callback: Called with (device_id, normalized_attrs) on updates
+            disconnect_callback: Called on connection loss (optional)
+            token_refresh_callback: Called to refresh token on HTTP 400 (optional)
+        """
+        self._device_id = device_id
+        self._service_region = service_region
+        self._token = token
+        self._update_callback = update_callback
+        self._disconnect_callback = disconnect_callback
+        self._token_refresh_callback = token_refresh_callback
+
+        self._websocket: ClientProtocol | None = None
+        self._listen_task: asyncio.Task[Any] | None = None
+        self._heartbeat_task: asyncio.Task[Any] | None = None
+        self._running = False
+        self._reconnect_count = 0
+        self._seq_id = int(time.time() * 1000)
+
+    @property
+    def ws_url(self) -> str:
+        """Get region-specific WebSocket endpoint."""
+        endpoint = ENDPOINTS.get(self._service_region, ENDPOINTS["eu-central-1"])
+        if self._service_region not in ENDPOINTS:
+            _LOGGER.warning(
+                "Unknown region %s for device %s, using EU",
+                self._service_region,
+                self._device_id[:12],
+            )
+        return endpoint
+
+    async def connect(self) -> None:
+        """Connect to region-specific WebSocket endpoint.
+
+        Establishes connection to AWS API Gateway with Authorization header
+        and starts background tasks for heartbeat and message listening.
+        """
+        if self._running:
+            _LOGGER.warning("WebSocket already running for device %s", self._device_id[:12])
+            return
+
+        _LOGGER.info(
+            "Connecting WebSocket for device %s (region: %s)",
+            self._device_id[:12],
+            self._service_region,
+        )
+
+        try:
+            # Use Home Assistant's SSL context
+            from homeassistant.util import ssl as ssl_util
+
+            ssl_context = ssl_util.get_default_context()
+
+            # Connect with Authorization header (no login message needed)
+            self._websocket = await websockets.connect(
+                self.ws_url,
+                additional_headers={"Authorization": self._token},
+                ssl=ssl_context,
+                ping_interval=None,  # Manual heartbeat
+            )
+
+            self._running = True
+            self._reconnect_count = 0  # Reset on successful connection
+
+            _LOGGER.info(
+                "✓ WebSocket connected for device %s", self._device_id[:12]
+            )
+
+            # Start background tasks
+            self._listen_task = asyncio.create_task(self._listen_loop())
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+        except Exception as err:
+            error_msg = str(err)
+            _LOGGER.error(
+                "WebSocket connection failed for device %s: %s",
+                self._device_id[:12],
+                error_msg,
+            )
+
+            # Handle HTTP 400 (token expired) - trigger refresh and immediate retry
+            if "HTTP 400" in error_msg and self._token_refresh_callback:
+                _LOGGER.info("HTTP 400 detected - attempting token refresh")
+                try:
+                    new_token = await self._token_refresh_callback()
+                    if new_token:
+                        self._token = new_token
+                        _LOGGER.info("Token refreshed, immediate retry")
+                        # Immediate retry (don't increment reconnect count)
+                        await self.connect()
+                        return
+                except Exception as refresh_err:
+                    _LOGGER.error("Token refresh failed: %s", str(refresh_err))
+
+            # Schedule reconnection with backoff
+            if not isinstance(err, asyncio.CancelledError):
+                await self._schedule_reconnect()
+
+    async def disconnect(self) -> None:
+        """Disconnect and cleanup resources.
+
+        Cancels background tasks and closes WebSocket connection gracefully.
+        Safe to call multiple times.
+        """
+        _LOGGER.info("Disconnecting WebSocket for device %s", self._device_id[:12])
+        self._running = False
+
+        # Cancel listen task
+        if self._listen_task and not self._listen_task.done():
+            self._listen_task.cancel()
+            try:
+                await self._listen_task
+            except asyncio.CancelledError:
+                pass
+
+        # Cancel heartbeat task
+        if self._heartbeat_task and not self._heartbeat_task.done():
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+
+        # Close WebSocket
+        if self._websocket:
+            try:
+                await self._websocket.close()
+            except Exception as ex:
+                _LOGGER.debug("Error closing WebSocket: %s", ex)
+            finally:
+                self._websocket = None
+
+        _LOGGER.info("✓ WebSocket disconnected for device %s", self._device_id[:12])
+
+    async def _listen_loop(self) -> None:
+        """Listen for incoming shadow update messages.
+
+        Processes device shadow deltas and triggers coordinator callback
+        with normalized attributes.
+        """
+        try:
+            if self._websocket is None:
+                return
+
+            async for message in self._websocket:
+                try:
+                    data = json.loads(message)
+                    await self._handle_message(data)
+
+                except json.JSONDecodeError:
+                    _LOGGER.warning("Received malformed JSON message")
+
+        except websockets.exceptions.ConnectionClosed:
+            _LOGGER.warning(
+                "WebSocket closed for device %s", self._device_id[:12]
+            )
+            # Trigger reconnection
+            if self._running:
+                await self._schedule_reconnect()
+
+        except Exception as err:
+            _LOGGER.error(
+                "Listen loop error for device %s: %s", self._device_id[:12], err
+            )
+            if self._running:
+                await self._schedule_reconnect()
+
+    async def _handle_message(self, data: dict[str, Any]) -> None:
+        """Process shadow delta message.
+
+        Args:
+            data: Parsed WebSocket message containing shadow state
+        """
+        # Extract shadow state (matches AWS IoT shadow delta format)
+        if "state" in data and "reported" in data.get("state", {}):
+            state = data["state"]["reported"]
+
+            _LOGGER.debug(
+                "Shadow update for device %s: %d fields",
+                self._device_id[:12],
+                len(state),
+            )
+
+            # Normalize AWS field names to Gizwits V01 equivalents using shared method
+            from .api import AwsIotApi
+            normalized = AwsIotApi.normalize_aws_state(state)
+
+            # Call coordinator callback with (device_id, normalized_attrs)
+            if self._update_callback:
+                try:
+                    self._update_callback(self._device_id, normalized)
+                except Exception as err:
+                    _LOGGER.error("Callback error: %s", err)
+
+    async def _heartbeat_loop(self) -> None:
+        """Send heartbeat every 30 seconds to maintain connection."""
+        while self._running:
+            try:
+                await asyncio.sleep(30)
+
+                if self._running and self._websocket:
+                    # Send application-level heartbeat (JSON message)
+                    message = {
+                        "action": "heartbeat",
+                        "req_event": "heartbeat_req",
+                        "seq_id": self._seq_id,
+                        "req_count": 1,
+                        "req": None,
+                    }
+                    await self._websocket.send(json.dumps(message))
+
+                    # Also send WebSocket protocol ping
+                    await self._websocket.ping()
+
+                    self._seq_id += 1
+                    _LOGGER.debug("Heartbeat sent for device %s", self._device_id[:12])
+
+            except asyncio.CancelledError:
+                break
+            except Exception as err:
+                _LOGGER.warning("Heartbeat failed for device %s: %s", self._device_id[:12], err)
+                break
+
+    async def _schedule_reconnect(self) -> None:
+        """Schedule reconnection with exponential backoff.
+
+        Delays: 3s → 6s → 12s → 24s → 48s → 60s (max)
+        """
+        if not self._running:
+            return
+
+        # Get delay based on reconnect count
+        delay_index = min(self._reconnect_count, len(RECONNECT_DELAYS) - 1)
+        delay = RECONNECT_DELAYS[delay_index]
+
+        _LOGGER.info(
+            "Reconnecting device %s in %ds (attempt %d)",
+            self._device_id[:12],
+            delay,
+            self._reconnect_count + 1,
+        )
+
+        # Increment for next attempt
+        self._reconnect_count += 1
+
+        # Wait and reconnect
+        await asyncio.sleep(delay)
+
+        if self._running:
+            await self.connect()

--- a/custom_components/bestway/aws_iot/websocket.py
+++ b/custom_components/bestway/aws_iot/websocket.py
@@ -17,10 +17,11 @@ import asyncio
 import json
 import logging
 import time
+from collections.abc import Awaitable
 from typing import Any, Callable
 
 import websockets
-from websockets.client import ClientProtocol
+from websockets.asyncio.client import ClientConnection
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ class AwsIotWebSocket:
         token: str,
         update_callback: Callable[[str, dict[str, Any]], None],
         disconnect_callback: Callable[[], None] | None = None,
-        token_refresh_callback: Callable[[], str] | None = None,
+        token_refresh_callback: Callable[[], Awaitable[str]] | None = None,
     ) -> None:
         """Initialize per-device WebSocket client.
 
@@ -73,7 +74,7 @@ class AwsIotWebSocket:
         self._disconnect_callback = disconnect_callback
         self._token_refresh_callback = token_refresh_callback
 
-        self._websocket: ClientProtocol | None = None
+        self._websocket: ClientConnection | None = None
         self._listen_task: asyncio.Task[Any] | None = None
         self._heartbeat_task: asyncio.Task[Any] | None = None
         self._running = False
@@ -99,7 +100,9 @@ class AwsIotWebSocket:
         and starts background tasks for heartbeat and message listening.
         """
         if self._running:
-            _LOGGER.warning("WebSocket already running for device %s", self._device_id[:12])
+            _LOGGER.warning(
+                "WebSocket already running for device %s", self._device_id[:12]
+            )
             return
 
         _LOGGER.info(
@@ -125,9 +128,7 @@ class AwsIotWebSocket:
             self._running = True
             self._reconnect_count = 0  # Reset on successful connection
 
-            _LOGGER.info(
-                "✓ WebSocket connected for device %s", self._device_id[:12]
-            )
+            _LOGGER.info("✓ WebSocket connected for device %s", self._device_id[:12])
 
             # Start background tasks
             self._listen_task = asyncio.create_task(self._listen_loop())
@@ -142,7 +143,7 @@ class AwsIotWebSocket:
             )
 
             # Handle HTTP 400 (token expired) - trigger refresh and immediate retry
-            if "HTTP 400" in error_msg and self._token_refresh_callback:
+            if "HTTP 400" in error_msg and self._token_refresh_callback is not None:
                 _LOGGER.info("HTTP 400 detected - attempting token refresh")
                 try:
                     new_token = await self._token_refresh_callback()
@@ -214,9 +215,7 @@ class AwsIotWebSocket:
                     _LOGGER.warning("Received malformed JSON message")
 
         except websockets.exceptions.ConnectionClosed:
-            _LOGGER.warning(
-                "WebSocket closed for device %s", self._device_id[:12]
-            )
+            _LOGGER.warning("WebSocket closed for device %s", self._device_id[:12])
             # Trigger reconnection
             if self._running:
                 await self._schedule_reconnect()
@@ -246,10 +245,11 @@ class AwsIotWebSocket:
 
             # Normalize AWS field names to Gizwits V01 equivalents using shared method
             from .api import AwsIotApi
+
             normalized = AwsIotApi.normalize_aws_state(state)
 
             # Call coordinator callback with (device_id, normalized_attrs)
-            if self._update_callback:
+            if self._update_callback is not None:
                 try:
                     self._update_callback(self._device_id, normalized)
                 except Exception as err:
@@ -281,7 +281,9 @@ class AwsIotWebSocket:
             except asyncio.CancelledError:
                 break
             except Exception as err:
-                _LOGGER.warning("Heartbeat failed for device %s: %s", self._device_id[:12], err)
+                _LOGGER.warning(
+                    "Heartbeat failed for device %s: %s", self._device_id[:12], err
+                )
                 break
 
     async def _schedule_reconnect(self) -> None:

--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -8,6 +8,8 @@ from logging import getLogger
 
 from typing import Any
 
+from ..const import BACKEND_AWS_IOT, BACKEND_GIZWITS
+
 _LOGGER = getLogger(__name__)
 
 
@@ -168,14 +170,14 @@ class BestwayDevice:
     is_online: bool
     ws_host: str = "m2m.gizwits.com"  # WebSocket hostname from bindings API
     ws_port: int = 8880  # WebSocket port from bindings API
-    backend: str = "gizwits"  # Backend type: "gizwits" or "aws_iot"
+    backend: str = BACKEND_GIZWITS  # Backend type: gizwits or aws_iot
     product_id: str | None = None  # For AWS IoT: model ID like "T53NN8"
     product_series: str | None = None  # For AWS IoT: series like "AIRJET", "HYDROJET"
 
     @property
     def device_type(self) -> BestwayDeviceType:
         """Get the derived device type based on backend."""
-        if self.backend == "aws_iot" and self.product_series:
+        if self.backend == BACKEND_AWS_IOT and self.product_series:
             return BestwayDeviceType.from_aws_product_series(self.product_series)
         return BestwayDeviceType.from_api_product_name(self.product_name)
 

--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -20,6 +20,11 @@ class BestwayDeviceType(Enum):
     HYDROJET_PRO_SPA = "Hydrojet Pro"
     POOL_FILTER = "Pool Filter"
     UNKNOWN = "Unknown"
+    # V02 backend device types (AWS IoT)
+    AIRJET_V02 = "Airjet V02"
+    ULTRAFIT_AIRJET_V02 = "Ultrafit Airjet V02"
+    HYDROJET_V02 = "Hydrojet V02"
+    HYDROJET_PRO_V02 = "Hydrojet Pro V02"
 
     @staticmethod
     def from_api_product_name(product_name: str) -> BestwayDeviceType:
@@ -37,6 +42,24 @@ class BestwayDeviceType(Enum):
             # Chinese translates to "pool filter"
             return BestwayDeviceType.POOL_FILTER
         return BestwayDeviceType.UNKNOWN
+
+    @staticmethod
+    def from_aws_product_series(product_series: str) -> BestwayDeviceType:
+        """Get the enum value based on AWS IoT 'product_series' field.
+
+        Args:
+            product_series: Product series from AWS IoT API (e.g., "AIRJET", "HYDROJET")
+
+        Returns:
+            Corresponding V02 device type enum value
+        """
+        mapping = {
+            "AIRJET": BestwayDeviceType.AIRJET_V02,
+            "ULTRAFIT_AIRJET": BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+            "HYDROJET": BestwayDeviceType.HYDROJET_V02,
+            "HYDROJET_PRO": BestwayDeviceType.HYDROJET_PRO_V02,
+        }
+        return mapping.get(product_series, BestwayDeviceType.UNKNOWN)
 
 
 class TemperatureUnit(Enum):
@@ -136,7 +159,7 @@ class BestwayDevice:
 
     protocol_version: int
     device_id: str
-    product_name: str
+    product_name: str  # For Gizwits: "Airjet", "Hydrojet_Pro", etc.
     alias: str
     mcu_soft_version: str
     mcu_hard_version: str
@@ -145,10 +168,15 @@ class BestwayDevice:
     is_online: bool
     ws_host: str = "m2m.gizwits.com"  # WebSocket hostname from bindings API
     ws_port: int = 8880  # WebSocket port from bindings API
+    backend: str = "gizwits"  # Backend type: "gizwits" or "aws_iot"
+    product_id: str | None = None  # For AWS IoT: model ID like "T53NN8"
+    product_series: str | None = None  # For AWS IoT: series like "AIRJET", "HYDROJET"
 
     @property
     def device_type(self) -> BestwayDeviceType:
-        """Get the derived device type."""
+        """Get the derived device type based on backend."""
+        if self.backend == "aws_iot" and self.product_series:
+            return BestwayDeviceType.from_aws_product_series(self.product_series)
         return BestwayDeviceType.from_api_product_name(self.product_name)
 
 

--- a/custom_components/bestway/binary_sensor.py
+++ b/custom_components/bestway/binary_sensor.py
@@ -70,6 +70,10 @@ async def async_setup_entry(
             BestwayDeviceType.AIRJET_V01_SPA,
             BestwayDeviceType.HYDROJET_SPA,
             BestwayDeviceType.HYDROJET_PRO_SPA,
+            BestwayDeviceType.AIRJET_V02,
+            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+            BestwayDeviceType.HYDROJET_V02,
+            BestwayDeviceType.HYDROJET_PRO_V02,
         ]:
             entities.extend(
                 [

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -197,15 +197,15 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
         """Return the current mode (HEAT or OFF)."""
         if not self.status:
             return None
-        return HVACMode.HEAT if self.status.attrs["heat"] == 3 else HVACMode.OFF
+        return HVACMode.HEAT if self.status.attrs["heat"] > 0 else HVACMode.OFF
 
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running action (HEATING or IDLE)."""
         if not self.status:
             return None
-        heat_on = self.status.attrs["heat"] == HydrojetHeat.ON
-        target_reached = self.status.attrs["word3"] == 1
+        heat_on = self.status.attrs["heat"] > 0
+        target_reached = self.status.attrs["heat"] == 4
         return (
             HVACAction.HEATING if (heat_on and not target_reached) else HVACAction.IDLE
         )

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -50,6 +50,17 @@ async def async_setup_entry(
                 AirjetV01HydrojetSpaThermostat(coordinator, config_entry, device_id)
             )
 
+        # V02 AWS IoT devices (use same entities - normalization handles field names)
+        if device.device_type in [
+            BestwayDeviceType.AIRJET_V02,
+            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+            BestwayDeviceType.HYDROJET_V02,
+            BestwayDeviceType.HYDROJET_PRO_V02,
+        ]:
+            entities.append(
+                AirjetV01HydrojetSpaThermostat(coordinator, config_entry, device_id)
+            )
+
     async_add_entities(entities)
 
 

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -21,6 +21,8 @@ from .bestway.api import (
     BestwayUserDoesNotExistException,
 )
 from .const import (
+    BACKEND_AWS_IOT,
+    BACKEND_GIZWITS,
     CONF_API_ROOT,
     CONF_API_ROOT_EU,
     CONF_API_ROOT_US,
@@ -94,11 +96,11 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                             selector.SelectSelectorConfig(
                                 options=[
                                     selector.SelectOptionDict(
-                                        value="gizwits",
+                                        value=BACKEND_GIZWITS,
                                         label="V01 - Bestway Connect / Lay-Z-Spa WiFi (Gizwits)",
                                     ),
                                     selector.SelectOptionDict(
-                                        value="aws_iot",
+                                        value=BACKEND_AWS_IOT,
                                         label="V02 - Bestway Smart Spa app (AWS IoT)",
                                     ),
                                 ]
@@ -111,7 +113,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         # Store backend choice and route to appropriate auth flow
         self._backend = user_input["backend"]
 
-        if self._backend == "gizwits":
+        if self._backend == BACKEND_GIZWITS:
             return await self.async_step_gizwits_auth()
         else:
             return await self.async_step_aws_iot_auth()
@@ -140,7 +142,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "unknown_connection_error"
         else:
             # Add backend field for Gizwits
-            config_entry_data["backend"] = "gizwits"
+            config_entry_data["backend"] = BACKEND_GIZWITS
             return self.async_create_entry(
                 title=user_input[CONF_USERNAME], data=config_entry_data
             )
@@ -291,7 +293,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title=f"Bestway Spa (V02 - {region})",
                     data={
-                        "backend": "aws_iot",
+                        "backend": BACKEND_AWS_IOT,
                         "visitor_id": visitor_id,
                         "token": token,
                         "location": "GB",  # Legacy field

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 
+from .aws_iot.api import AwsIotAuthException
 from .bestway.api import (
     BestwayApi,
     BestwayIncorrectPasswordException,
@@ -75,13 +76,53 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
+    def __init__(self) -> None:
+        """Initialize config flow."""
+        super().__init__()
+        self._backend: str | None = None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Handle the initial step - backend selection."""
         if user_input is None:
             return self.async_show_form(
-                step_id="user", data_schema=_STEP_USER_DATA_SCHEMA
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("backend"): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=[
+                                    selector.SelectOptionDict(
+                                        value="gizwits",
+                                        label="V01 - Bestway Connect / Lay-Z-Spa WiFi (Gizwits)",
+                                    ),
+                                    selector.SelectOptionDict(
+                                        value="aws_iot",
+                                        label="V02 - Bestway Smart Spa app (AWS IoT)",
+                                    ),
+                                ]
+                            )
+                        ),
+                    }
+                ),
+            )
+
+        # Store backend choice and route to appropriate auth flow
+        self._backend = user_input["backend"]
+
+        if self._backend == "gizwits":
+            return await self.async_step_gizwits_auth()
+        else:
+            return await self.async_step_aws_iot_auth()
+
+    async def async_step_gizwits_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle Gizwits authentication (V01 backend)."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="gizwits_auth", data_schema=_STEP_USER_DATA_SCHEMA
             )
 
         errors = {}
@@ -98,10 +139,190 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown_connection_error"
         else:
+            # Add backend field for Gizwits
+            config_entry_data["backend"] = "gizwits"
             return self.async_create_entry(
                 title=user_input[CONF_USERNAME], data=config_entry_data
             )
 
         return self.async_show_form(
-            step_id="user", data_schema=_STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="gizwits_auth", data_schema=_STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_aws_iot_auth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle AWS IoT authentication (V02 backend) - QR code OR visitor_id."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="aws_iot_auth",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("region", default="EU"): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=[
+                                    selector.SelectOptionDict(value="EU", label="Europe"),
+                                    selector.SelectOptionDict(value="US", label="United States"),
+                                    selector.SelectOptionDict(value="CN", label="China"),
+                                ]
+                            )
+                        ),
+                        vol.Optional("visitor_id"): str,
+                        vol.Optional("qr_code"): str,
+                    }
+                ),
+                description_placeholders={
+                    "qr_help": "Scan QR from app Settings → Device Sharing",
+                    "visitor_help": "OR enter visitor_id from existing account",
+                },
+            )
+
+        errors = {}
+        region = user_input.get("region", "EU")
+        qr_code = user_input.get("qr_code", "").strip()
+        visitor_id_input = user_input.get("visitor_id", "").strip()
+
+        # Require one or the other
+        if not qr_code and not visitor_id_input:
+            errors["base"] = "qr_or_visitor_required"
+            return self.async_show_form(
+                step_id="aws_iot_auth",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required("region", default=region): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=[
+                                    selector.SelectOptionDict(value="EU", label="Europe"),
+                                    selector.SelectOptionDict(value="US", label="United States"),
+                                    selector.SelectOptionDict(value="CN", label="China"),
+                                ]
+                            )
+                        ),
+                        vol.Optional("visitor_id"): str,
+                        vol.Optional("qr_code"): str,
+                    }
+                ),
+                errors=errors,
+            )
+
+        try:
+            from .aws_iot.api import AwsIotApi, API_ENDPOINTS
+
+            session = async_get_clientsession(self.hass)
+
+            # Map region to API endpoint
+            api_base = API_ENDPOINTS.get(region, API_ENDPOINTS["EU"])
+
+            # Determine visitor_id
+            if qr_code:
+                # Validate QR format
+                if not qr_code.startswith("RW_Share_"):
+                    errors["qr_code"] = "invalid_qr_format"
+                    return self.async_show_form(
+                        step_id="aws_iot_auth",
+                        data_schema=vol.Schema(
+                            {
+                                vol.Optional("qr_code"): str,
+                                vol.Optional("visitor_id"): str,
+                            }
+                        ),
+                        errors=errors,
+                    )
+
+                # Generate visitor_id for new account
+                visitor_id = AwsIotApi.generate_visitor_id()
+
+                # Authenticate to get token
+                token = await AwsIotApi.authenticate(session, visitor_id, api_base=api_base)
+
+                # Bind QR code to visitor account
+                try:
+                    device_info = await AwsIotApi.bind_qr_code(
+                        session, qr_code, visitor_id, token, api_base=api_base
+                    )
+                    if not device_info:
+                        errors["qr_code"] = "binding_failed"
+                        return self.async_show_form(
+                            step_id="aws_iot_auth",
+                            data_schema=vol.Schema(
+                                {
+                                    vol.Optional("qr_code"): str,
+                                    vol.Optional("visitor_id"): str,
+                                }
+                            ),
+                            errors=errors,
+                        )
+                except Exception as bind_err:
+                    _LOGGER.error("QR binding failed: %s", bind_err)
+                    errors["qr_code"] = "binding_failed"
+                    return self.async_show_form(
+                        step_id="aws_iot_auth",
+                        data_schema=vol.Schema(
+                            {
+                                vol.Optional("qr_code"): str,
+                                vol.Optional("visitor_id"): str,
+                            }
+                        ),
+                        errors=errors,
+                    )
+            else:
+                # Use provided visitor_id
+                visitor_id = visitor_id_input
+
+                # Authenticate to get token
+                token = await AwsIotApi.authenticate(session, visitor_id, api_base=api_base)
+
+            # Test by discovering devices
+            api = AwsIotApi(
+                session=session,
+                visitor_id=visitor_id,
+                token=token,
+                api_base=api_base,
+            )
+
+            async with asyncio.timeout(10):
+                await api.refresh_bindings()
+
+            # Verify at least one device found
+            if not api.devices:
+                errors["base"] = "no_devices_found"
+            else:
+                # Create entry with AWS IoT backend (no device_id - multi-device!)
+                return self.async_create_entry(
+                    title=f"Bestway Spa (V02 - {region})",
+                    data={
+                        "backend": "aws_iot",
+                        "visitor_id": visitor_id,
+                        "token": token,
+                        "location": "GB",  # Legacy field
+                        "region": region,
+                        "api_base": api_base,
+                    },
+                )
+
+        except AwsIotAuthException as auth_err:
+            _LOGGER.error("AWS IoT authentication failed: %s", auth_err)
+            errors["base"] = "auth_failed"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("AWS IoT setup failed")
+            errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="aws_iot_auth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("region", default=region): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(value="EU", label="Europe"),
+                                selector.SelectOptionDict(value="US", label="United States"),
+                                selector.SelectOptionDict(value="CN", label="China"),
+                            ]
+                        )
+                    ),
+                    vol.Optional("visitor_id"): str,
+                    vol.Optional("qr_code"): str,
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -163,9 +163,15 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                         vol.Required("region", default="EU"): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=[
-                                    selector.SelectOptionDict(value="EU", label="Europe"),
-                                    selector.SelectOptionDict(value="US", label="United States"),
-                                    selector.SelectOptionDict(value="CN", label="China"),
+                                    selector.SelectOptionDict(
+                                        value="EU", label="Europe"
+                                    ),
+                                    selector.SelectOptionDict(
+                                        value="US", label="United States"
+                                    ),
+                                    selector.SelectOptionDict(
+                                        value="CN", label="China"
+                                    ),
                                 ]
                             )
                         ),
@@ -194,9 +200,15 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                         vol.Required("region", default=region): selector.SelectSelector(
                             selector.SelectSelectorConfig(
                                 options=[
-                                    selector.SelectOptionDict(value="EU", label="Europe"),
-                                    selector.SelectOptionDict(value="US", label="United States"),
-                                    selector.SelectOptionDict(value="CN", label="China"),
+                                    selector.SelectOptionDict(
+                                        value="EU", label="Europe"
+                                    ),
+                                    selector.SelectOptionDict(
+                                        value="US", label="United States"
+                                    ),
+                                    selector.SelectOptionDict(
+                                        value="CN", label="China"
+                                    ),
                                 ]
                             )
                         ),
@@ -235,7 +247,9 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                 visitor_id = AwsIotApi.generate_visitor_id()
 
                 # Authenticate to get token
-                token = await AwsIotApi.authenticate(session, visitor_id, api_base=api_base)
+                token = await AwsIotApi.authenticate(
+                    session, visitor_id, api_base=api_base
+                )
 
                 # Bind QR code to visitor account
                 try:
@@ -272,7 +286,9 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                 visitor_id = visitor_id_input
 
                 # Authenticate to get token
-                token = await AwsIotApi.authenticate(session, visitor_id, api_base=api_base)
+                token = await AwsIotApi.authenticate(
+                    session, visitor_id, api_base=api_base
+                )
 
             # Test by discovering devices
             api = AwsIotApi(
@@ -317,7 +333,9 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                         selector.SelectSelectorConfig(
                             options=[
                                 selector.SelectOptionDict(value="EU", label="Europe"),
-                                selector.SelectOptionDict(value="US", label="United States"),
+                                selector.SelectOptionDict(
+                                    value="US", label="United States"
+                                ),
                                 selector.SelectOptionDict(value="CN", label="China"),
                             ]
                         )

--- a/custom_components/bestway/const.py
+++ b/custom_components/bestway/const.py
@@ -13,6 +13,10 @@ CONF_USER_TOKEN_EXPIRY = "user_token_expiry"
 CONF_UID = "uid"
 GIZWITS_APP_ID = "98754e684ec045528b073876c34c7348"
 
+# Backend types
+BACKEND_GIZWITS = "gizwits"
+BACKEND_AWS_IOT = "aws_iot"
+
 
 class Icon(str, Enum):
     """Icon styles."""

--- a/custom_components/bestway/coordinator.py
+++ b/custom_components/bestway/coordinator.py
@@ -59,10 +59,18 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
             "WebSocket update for device %s with %d attributes", device_id, len(attrs)
         )
 
-        # Update state cache with real-time data
+        # Merge WebSocket updates with existing state to preserve diagnostic fields
+        # WebSocket deltas only include changed fields, not full state
+        existing = self.api._state_cache.get(device_id)
+        if existing:
+            merged_attrs = {**existing.attrs, **attrs}
+        else:
+            merged_attrs = attrs
+
+        # Update state cache with merged data
         self.api._state_cache[device_id] = BestwayDeviceStatus(
             timestamp=int(time()),
-            attrs=attrs,
+            attrs=merged_attrs,
         )
 
         # Track last WebSocket update time for this device

--- a/custom_components/bestway/coordinator.py
+++ b/custom_components/bestway/coordinator.py
@@ -10,8 +10,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from .aws_iot.api import AwsIotApi
+from .aws_iot.websocket import AwsIotWebSocket
 from .bestway.api import BestwayApi, BestwayApiResults
 from .bestway.model import BestwayDeviceStatus
+from .bestway.websocket import GizwitsWebSocket
 
 _LOGGER = getLogger(__name__)
 
@@ -20,7 +23,10 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
     """Update coordinator that polls the device status for all devices in an account."""
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigEntry, api: BestwayApi
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        api: BestwayApi | AwsIotApi,
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(
@@ -32,7 +38,8 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
         )
         self.api = api
         self._ws_last_update: dict[str, float] = {}  # Track WebSocket update times
-        self.websocket: Any = None  # WebSocket client (set in __init__.py)
+        self.websocket: GizwitsWebSocket | None = None
+        self.websockets: list[AwsIotWebSocket] = []
 
     async def _async_update_data(self) -> BestwayApiResults:
         """Fetch data from API endpoint.

--- a/custom_components/bestway/entity.py
+++ b/custom_components/bestway/entity.py
@@ -29,13 +29,24 @@ class BestwayEntity(CoordinatorEntity[BestwayUpdateCoordinator]):
     def device_info(self) -> DeviceInfo:
         """Device information for the spa providing this entity."""
 
-        device_info = self.coordinator.api.devices[self.device_id]
+        device = self.coordinator.api.devices[self.device_id]
+
+        # Build model string like reference: "AIRJET (T53NN8)" or just device type
+        if device.product_series and device.product_id:
+            model = f"{device.product_series} ({device.product_id})"
+        elif device.product_id:
+            model = device.product_id
+        elif device.product_series:
+            model = device.product_series
+        else:
+            model = device.device_type.value
 
         return DeviceInfo(
             identifiers={(DOMAIN, self.device_id)},
-            name=device_info.alias,
-            model=device_info.device_type.value,
+            name=device.alias,
+            model=model,
             manufacturer="Bestway",
+            sw_version=device.mcu_soft_version,  # Add version info
         )
 
     @property

--- a/custom_components/bestway/manifest.json
+++ b/custom_components/bestway/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "device",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/cdpuk/ha-bestway/issues",
-  "requirements": ["websockets"],
+  "requirements": ["pycryptodome>=3.20.0", "websockets>=13.0"],
   "version": "1.7.0"
 }

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -68,7 +68,11 @@ async def async_setup_entry(
     entities: list[BestwayEntity] = []
 
     for device_id, device in coordinator.api.devices.items():
-        if device.device_type == BestwayDeviceType.AIRJET_V01_SPA:
+        if device.device_type in [
+            BestwayDeviceType.AIRJET_V01_SPA,
+            BestwayDeviceType.AIRJET_V02,
+            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+        ]:
             entities.append(
                 ThreeWaySpaBubblesSelect(
                     coordinator,
@@ -81,6 +85,8 @@ async def async_setup_entry(
         if device.device_type in [
             BestwayDeviceType.HYDROJET_SPA,
             BestwayDeviceType.HYDROJET_PRO_SPA,
+            BestwayDeviceType.HYDROJET_V02,
+            BestwayDeviceType.HYDROJET_PRO_V02,
         ]:
             entities.append(
                 ThreeWaySpaBubblesSelect(

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -10,9 +10,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from custom_components.bestway.bestway.api import BestwayApi
-
 from . import BestwayUpdateCoordinator
+from .aws_iot.api import AwsIotApi
+from .bestway.api import BestwayApi
 from .bestway.model import (
     AIRJET_V01_BUBBLES_MAP,
     HYDROJET_BUBBLES_MAP,
@@ -33,7 +33,7 @@ _BUBBLES_OPTIONS = {
 class BubblesSelectEntityDescription(SelectEntityDescription):
     """Describes bubbles selection."""
 
-    set_fn: Callable[[BestwayApi, str, BubblesLevel], Awaitable[None]]
+    set_fn: Callable[[BestwayApi | AwsIotApi, str, BubblesLevel], Awaitable[None]]
     get_fn: Callable[[int], BubblesLevel]
 
 

--- a/custom_components/bestway/sensor.py
+++ b/custom_components/bestway/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.typing import StateType
 
 from . import BestwayUpdateCoordinator
 from .bestway.model import BestwayDevice, BestwayDeviceType
-from .const import DOMAIN, Icon
+from .const import BACKEND_GIZWITS, DOMAIN, Icon
 from .entity import BestwayEntity
 
 
@@ -50,80 +50,125 @@ async def async_setup_entry(
         elif device_info.device_type == BestwayDeviceType.POOL_FILTER:
             name_prefix = "Pool Filter"
 
-        entities.extend(
-            [
-                DeviceSensor(
-                    coordinator,
-                    config_entry,
-                    device_id,
-                    sensor_description=DeviceSensorDescription(
+        # Version sensors - different for V01 vs V02
+        if device_info.backend == BACKEND_GIZWITS:
+            # V01 Gizwits devices: Show MCU and WiFi versions from device object
+            entities.extend(
+                [
+                    DeviceSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        sensor_description=DeviceSensorDescription(
+                            SensorEntityDescription(
+                                key="protocol_version",
+                                name=f"{name_prefix} Protocol Version",
+                                icon=Icon.PROTOCOL,
+                                entity_category=EntityCategory.DIAGNOSTIC,
+                            ),
+                            lambda device: device.protocol_version,
+                        ),
+                    ),
+                    DeviceSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        sensor_description=DeviceSensorDescription(
+                            SensorEntityDescription(
+                                key="mcu_soft_version",
+                                name=f"{name_prefix} MCU Software Version",
+                                icon=Icon.SOFTWARE,
+                                entity_category=EntityCategory.DIAGNOSTIC,
+                            ),
+                            lambda device: device.mcu_soft_version,
+                        ),
+                    ),
+                    DeviceSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        sensor_description=DeviceSensorDescription(
+                            SensorEntityDescription(
+                                key="mcu_hard_version",
+                                name=f"{name_prefix} MCU Hardware Version",
+                                icon=Icon.HARDWARE,
+                                entity_category=EntityCategory.DIAGNOSTIC,
+                            ),
+                            lambda device: device.mcu_hard_version,
+                        ),
+                    ),
+                    DeviceSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        sensor_description=DeviceSensorDescription(
+                            SensorEntityDescription(
+                                key="wifi_soft_version",
+                                name=f"{name_prefix} Wi-Fi Software Version",
+                                icon=Icon.SOFTWARE,
+                                entity_category=EntityCategory.DIAGNOSTIC,
+                            ),
+                            lambda device: device.wifi_soft_version,
+                        ),
+                    ),
+                    DeviceSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        sensor_description=DeviceSensorDescription(
+                            SensorEntityDescription(
+                                key="wifi_hard_version",
+                                name=f"{name_prefix} Wi-Fi Hardware Version",
+                                icon=Icon.HARDWARE,
+                                entity_category=EntityCategory.DIAGNOSTIC,
+                            ),
+                            lambda device: device.wifi_hard_version,
+                        ),
+                    ),
+                ]
+            )
+        else:
+            # V02 AWS IoT devices: Show WiFi, TRD, OTA from shadow state
+            entities.extend(
+                [
+                    StateSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
                         SensorEntityDescription(
-                            key="protocol_version",
-                            name=f"{name_prefix} Protocol Version",
+                            key="wifi_version",
+                            name=f"{name_prefix} WiFi Version",
+                            icon=Icon.SOFTWARE,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                        "wifi_version",
+                    ),
+                    StateSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        SensorEntityDescription(
+                            key="trd_version",
+                            name=f"{name_prefix} TRD Version",
+                            icon=Icon.SOFTWARE,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                        ),
+                        "trd_version",
+                    ),
+                    StateSensor(
+                        coordinator,
+                        config_entry,
+                        device_id,
+                        SensorEntityDescription(
+                            key="ota_status",
+                            name=f"{name_prefix} OTA Status",
                             icon=Icon.PROTOCOL,
                             entity_category=EntityCategory.DIAGNOSTIC,
                         ),
-                        lambda device: device.protocol_version,
+                        "ota_status",
                     ),
-                ),
-                DeviceSensor(
-                    coordinator,
-                    config_entry,
-                    device_id,
-                    sensor_description=DeviceSensorDescription(
-                        SensorEntityDescription(
-                            key="mcu_soft_version",
-                            name=f"{name_prefix} MCU Software Version",
-                            icon=Icon.SOFTWARE,
-                            entity_category=EntityCategory.DIAGNOSTIC,
-                        ),
-                        lambda device: device.mcu_soft_version,
-                    ),
-                ),
-                DeviceSensor(
-                    coordinator,
-                    config_entry,
-                    device_id,
-                    sensor_description=DeviceSensorDescription(
-                        SensorEntityDescription(
-                            key="mcu_hard_version",
-                            name=f"{name_prefix} MCU Hardware Version",
-                            icon=Icon.HARDWARE,
-                            entity_category=EntityCategory.DIAGNOSTIC,
-                        ),
-                        lambda device: device.mcu_hard_version,
-                    ),
-                ),
-                DeviceSensor(
-                    coordinator,
-                    config_entry,
-                    device_id,
-                    sensor_description=DeviceSensorDescription(
-                        SensorEntityDescription(
-                            key="wifi_soft_version",
-                            name=f"{name_prefix} Wi-Fi Software Version",
-                            icon=Icon.SOFTWARE,
-                            entity_category=EntityCategory.DIAGNOSTIC,
-                        ),
-                        lambda device: device.wifi_soft_version,
-                    ),
-                ),
-                DeviceSensor(
-                    coordinator,
-                    config_entry,
-                    device_id,
-                    sensor_description=DeviceSensorDescription(
-                        SensorEntityDescription(
-                            key="wifi_hard_version",
-                            name=f"{name_prefix} Wi-Fi Hardware Version",
-                            icon=Icon.HARDWARE,
-                            entity_category=EntityCategory.DIAGNOSTIC,
-                        ),
-                        lambda device: device.wifi_hard_version,
-                    ),
-                ),
-            ]
-        )
+                ]
+            )
 
     async_add_entities(entities)
 
@@ -151,4 +196,29 @@ class DeviceSensor(BestwayEntity, SensorEntity):
         """Return the relevant property."""
         if (device := self.bestway_device) is not None:
             return self.sensor_description.value_fn(device)
+        return None
+
+
+class StateSensor(BestwayEntity, SensorEntity):
+    """A sensor based on device state attributes (for V02 devices)."""
+
+    def __init__(
+        self,
+        coordinator: BestwayUpdateCoordinator,
+        config_entry: ConfigEntry,
+        device_id: str,
+        entity_description: SensorEntityDescription,
+        state_key: str,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, config_entry, device_id)
+        self.entity_description = entity_description
+        self._state_key = state_key
+        self._attr_unique_id = f"{device_id}_{entity_description.key}"
+
+    @property
+    def native_value(self) -> StateType:
+        """Return value from state attrs."""
+        if self.status is not None:
+            return self.status.attrs.get(self._state_key)
         return None

--- a/custom_components/bestway/sensor.py
+++ b/custom_components/bestway/sensor.py
@@ -41,6 +41,10 @@ async def async_setup_entry(
             BestwayDeviceType.AIRJET_SPA,
             BestwayDeviceType.HYDROJET_SPA,
             BestwayDeviceType.HYDROJET_PRO_SPA,
+            BestwayDeviceType.AIRJET_V02,
+            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+            BestwayDeviceType.HYDROJET_V02,
+            BestwayDeviceType.HYDROJET_PRO_V02,
         ]:
             name_prefix = "Spa"
         elif device_info.device_type == BestwayDeviceType.POOL_FILTER:

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -143,7 +143,12 @@ async def async_setup_entry(
                 ]
             )
 
-        if device.device_type == BestwayDeviceType.AIRJET_V01_SPA:
+        # V01 and V02 Airjet devices (normalization provides consistent field names)
+        if device.device_type in [
+            BestwayDeviceType.AIRJET_V01_SPA,
+            BestwayDeviceType.AIRJET_V02,
+            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+        ]:
             entities.extend(
                 [
                     BestwaySwitch(
@@ -161,9 +166,12 @@ async def async_setup_entry(
                 ]
             )
 
+        # V01 and V02 Hydrojet devices (normalization provides consistent field names)
         if device.device_type in [
             BestwayDeviceType.HYDROJET_SPA,
             BestwayDeviceType.HYDROJET_PRO_SPA,
+            BestwayDeviceType.HYDROJET_V02,
+            BestwayDeviceType.HYDROJET_PRO_V02,
         ]:
             entities.extend(
                 [

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BestwayUpdateCoordinator
+from .aws_iot.api import AwsIotApi
 from .bestway.api import BestwayApi
 from .bestway.model import BestwayDeviceStatus, BestwayDeviceType, HydrojetFilter
 from .const import DOMAIN, Icon
@@ -24,8 +25,8 @@ class BestwaySwitchEntityDescription(SwitchEntityDescription):
     """Entity description for bestway spa switches."""
 
     value_fn: Callable[[BestwayDeviceStatus], bool]
-    turn_on_fn: Callable[[BestwayApi, str], Awaitable[None]]
-    turn_off_fn: Callable[[BestwayApi, str], Awaitable[None]]
+    turn_on_fn: Callable[[BestwayApi | AwsIotApi, str], Awaitable[None]]
+    turn_off_fn: Callable[[BestwayApi | AwsIotApi, str], Awaitable[None]]
 
 
 _AIRJET_SPA_POWER_SWITCH = BestwaySwitchEntityDescription(

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -2,11 +2,28 @@
   "config": {
     "step": {
       "user": {
-        "title": "Bestway Login",
+        "title": "Select Bestway App Type",
+        "description": "Choose which Bestway app you use to control your spa",
+        "data": {
+          "backend": "App Type"
+        }
+      },
+      "gizwits_auth": {
+        "title": "Bestway V01 Login (Gizwits)",
+        "description": "Enter your Bestway Connect or Lay-Z-Spa WiFi app credentials",
         "data": {
           "username": "Username (e-mail address)",
           "password": "Password",
           "apiroot": "API location"
+        }
+      },
+      "aws_iot_auth": {
+        "title": "Setup Bestway Spa",
+        "description": "Choose setup method: Use an existing visitor_id OR scan a QR code to create a new account. Provide ONE option only.",
+        "data": {
+          "region": "Region",
+          "visitor_id": "Visitor ID (existing account, optional)",
+          "qr_code": "QR Code (new account, optional)"
         }
       }
     },
@@ -14,7 +31,16 @@
       "cannot_connect": "Could not connect to the Bestway API",
       "user_does_not_exist": "User account does not exist",
       "incorrect_password": "Incorrect password",
-      "unknown_connection_error": "Unexpected connector error - check logs for details"
+      "unknown_connection_error": "Unexpected connector error - check logs for details",
+      "invalid_auth": "Invalid authentication",
+      "auth_failed": "Authentication failed. Please try again.",
+      "qr_or_visitor_required": "Either provide an existing visitor_id OR scan a QR code. One option is required.",
+      "invalid_qr_format": "Invalid QR code format. QR code must start with 'RW_Share_'.",
+      "invalid_format": "Invalid QR code format. QR code must start with 'RW_Share_'.",
+      "binding_failed": "QR code binding failed. The code may be expired or already used. Generate a fresh QR code from your spa.",
+      "no_devices_found": "No devices found. Please check your spa is powered on and connected.",
+      "qr_code_required": "Either provide an existing visitor_id OR scan a QR code. One option is required.",
+      "unknown": "Unknown error"
     }
   }
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
+pycryptodome>=3.20.0
 pytest-homeassistant-custom-component
 websockets

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -6,8 +6,6 @@ import pytest
 from custom_components.bestway.aws_iot.api import (
     AwsIotApi,
     AwsIotAuthException,
-    FIELD_MAPPING,
-    GIZWITS_TO_AWS_FIELDS,
 )
 from custom_components.bestway.bestway.model import BestwayDeviceType
 
@@ -160,52 +158,83 @@ async def test_refresh_bindings_multiple_devices(aws_api, mock_session):
     assert aws_api.devices["device2"].alias == "Spa 2"
 
 
-def test_normalize_state_comprehensive(aws_api):
+def test_normalize_state_comprehensive():
     """Test comprehensive field normalization including power, temperature, and wave."""
     aws_state = {
         "power_state": 1,
         "heater_state": 0,
         "temperature_setting": 37,
-        "current_temperature": 36,
+        "water_temperature": 36,
         "temperature_unit": 1,
         "wave_state": 100,
+        "warning": "",
+        "error_code": "",
     }
-    normalized = aws_api._normalize_state(aws_state)
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
 
     # Power fields
     assert normalized["power"] is True
     assert normalized["heat"] == 0
 
     # Temperature fields
-    assert normalized["temp_set"] == 37
-    assert normalized["temp_now"] == 36
-    assert normalized["temp_set_unit"] == 1
+    assert normalized["Tset"] == 37
+    assert normalized["Tnow"] == 36
+    assert normalized["Tunit"] == 1
 
     # Wave field
     assert normalized["wave"] == 100
 
 
-def test_normalize_state_filter(aws_api):
-    """Test filter_state normalization (2=ON)."""
+def test_normalize_state_filter():
+    """Test filter_state normalization."""
     # Filter on
     aws_state = {"filter_state": 2}
-    normalized = aws_api._normalize_state(aws_state)
-    assert normalized["filter_power"] is True
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
+    assert normalized["filter"] == 2
 
     # Filter off
     aws_state = {"filter_state": 0}
-    normalized = aws_api._normalize_state(aws_state)
-    assert normalized["filter_power"] is False
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
+    assert normalized["filter"] == 0
 
 
-def test_normalize_state_unmapped_fields(aws_api):
-    """Test unmapped fields are preserved with aws_ prefix."""
-    aws_state = {"power_state": 1, "unknown_field": 42, "debug_info": "test"}
-    normalized = aws_api._normalize_state(aws_state)
+def test_normalize_state_partial_update_preserves_absent_fields():
+    """Test that partial WebSocket updates don't overwrite absent fields.
 
-    assert normalized["power"] is True
-    assert normalized["aws_unknown_field"] == 42
-    assert normalized["aws_debug_info"] == "test"
+    Regression test for temperature unit flip-flop bug: WebSocket deltas
+    that omit temperature_unit should not default it to Celsius (1),
+    which would overwrite a Fahrenheit (0) setting.
+    """
+    # Simulate a partial WebSocket delta with only temperature change
+    partial_state = {
+        "water_temperature": 30,
+    }
+    normalized = AwsIotApi.normalize_aws_state(partial_state)
+
+    # temperature_unit was not in the delta, so Tunit should not be set
+    assert "Tunit" not in normalized
+    # warning/error also absent, should not be set
+    assert "warning" not in normalized
+    assert "error" not in normalized
+    # The field that was present should be set
+    assert normalized["Tnow"] == 30
+
+
+def test_normalize_state_wave_mapping():
+    """Test V02 wave_state value mapping to V01 format."""
+    # V02 MEDIUM (40) maps to V01 Airjet MEDIUM (50)
+    aws_state = {"wave_state": 40}
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
+    assert normalized["wave"] == 50
+
+    # 0 and 100 are the same in both versions
+    aws_state = {"wave_state": 0}
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
+    assert normalized["wave"] == 0
+
+    aws_state = {"wave_state": 100}
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
+    assert normalized["wave"] == 100
 
 
 @pytest.mark.asyncio
@@ -251,8 +280,8 @@ async def test_fetch_data_returns_results(aws_api, mock_session):
     status = results.devices["device1"]
     assert status.attrs["power"] is True
     assert status.attrs["heat"] == 3
-    assert status.attrs["temp_set"] == 37
-    assert status.attrs["temp_now"] == 36
+    assert status.attrs["Tset"] == 37
+    assert status.attrs["Tnow"] == 36
 
 
 @pytest.mark.asyncio

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -1,0 +1,288 @@
+"""Tests for AWS IoT API client."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from custom_components.bestway.aws_iot.api import (
+    AwsIotApi,
+    AwsIotAuthException,
+    FIELD_MAPPING,
+    GIZWITS_TO_AWS_FIELDS,
+)
+from custom_components.bestway.bestway.model import BestwayDeviceType
+
+
+def create_mock_response(status: int, json_data: dict):
+    """Create a properly mocked aiohttp response with context manager support."""
+    response = AsyncMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+    return response
+
+
+@pytest.fixture
+def mock_session():
+    """Create mock aiohttp ClientSession."""
+    session = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def aws_api(mock_session):
+    """Create AwsIotApi instance for testing."""
+    return AwsIotApi(
+        session=mock_session,
+        visitor_id="test_visitor_123",
+        token="test_token_456",
+        location="GB",
+    )
+
+
+def test_signature_deterministic(aws_api):
+    """Test signature is deterministic for same inputs."""
+    # Use _generate_auth_headers which returns full headers dict
+    # Signature is deterministic within the same timestamp second
+    headers1 = aws_api._generate_auth_headers()
+    headers2 = aws_api._generate_auth_headers()
+
+    # Both should have 'sign' field
+    assert "sign" in headers1
+    assert "sign" in headers2
+    # Signatures should be 32-char hex strings (MD5)
+    assert len(headers1["sign"]) == 32
+    assert len(headers2["sign"]) == 32
+
+
+def test_signature_different_for_different_inputs(aws_api):
+    """Test signature changes with different inputs."""
+    import time
+
+    # Get first signature
+    headers1 = aws_api._generate_auth_headers()
+    sig1 = headers1["sign"]
+
+    # Wait to ensure different timestamp
+    time.sleep(1)
+
+    # Get second signature - should be different due to timestamp change
+    headers2 = aws_api._generate_auth_headers()
+    sig2 = headers2["sign"]
+
+    # Signatures include timestamp, so they should differ
+    assert sig1 != sig2
+
+
+@pytest.mark.asyncio
+async def test_refresh_bindings_discovers_devices(aws_api, mock_session):
+    """Test device discovery populates devices dict."""
+    # Mock API responses with context manager support
+    homes_response = create_mock_response(200, {"list": [{"home_id": "home1"}]})
+    rooms_response = create_mock_response(200, {"list": [{"room_id": "room1"}]})
+    devices_response = create_mock_response(
+        200,
+        {
+            "list": [
+                {
+                    "device_id": "device123",
+                    "device_alias": "Test Spa",
+                    "product_series": "AIRJET",
+                    "service_region": "eu-central-1",
+                    "is_online": True,
+                }
+            ]
+        },
+    )
+
+    mock_session.get = MagicMock(side_effect=[homes_response, rooms_response, devices_response])
+
+    # Execute
+    await aws_api.refresh_bindings()
+
+    # Verify
+    assert len(aws_api.devices) == 1
+    assert "device123" in aws_api.devices
+
+    device = aws_api.devices["device123"]
+    assert device.device_id == "device123"
+    assert device.alias == "Test Spa"
+    assert device.backend == "aws_iot"
+    assert device.protocol_version == 2
+    assert device.ws_host == "eu-central-1"  # Region stored in ws_host
+
+
+@pytest.mark.asyncio
+async def test_refresh_bindings_multiple_devices(aws_api, mock_session):
+    """Test discovery of multiple devices across rooms."""
+    # 1 home, 2 rooms, 1 device per room
+    homes_response = create_mock_response(200, {"list": [{"home_id": "home1"}]})
+    rooms_response = create_mock_response(
+        200, {"list": [{"room_id": "room1"}, {"room_id": "room2"}]}
+    )
+    devices1_response = create_mock_response(
+        200,
+        {
+            "list": [
+                {
+                    "device_id": "device1",
+                    "device_alias": "Spa 1",
+                    "product_series": "AIRJET",
+                    "service_region": "eu-central-1",
+                }
+            ]
+        },
+    )
+    devices2_response = create_mock_response(
+        200,
+        {
+            "list": [
+                {
+                    "device_id": "device2",
+                    "device_alias": "Spa 2",
+                    "product_series": "HYDROJET",
+                    "service_region": "us-east-1",
+                }
+            ]
+        },
+    )
+
+    mock_session.get = MagicMock(
+        side_effect=[homes_response, rooms_response, devices1_response, devices2_response]
+    )
+
+    await aws_api.refresh_bindings()
+
+    assert len(aws_api.devices) == 2
+    assert "device1" in aws_api.devices
+    assert "device2" in aws_api.devices
+    assert aws_api.devices["device1"].alias == "Spa 1"
+    assert aws_api.devices["device2"].alias == "Spa 2"
+
+
+def test_normalize_state_comprehensive(aws_api):
+    """Test comprehensive field normalization including power, temperature, and wave."""
+    aws_state = {
+        "power_state": 1,
+        "heater_state": 0,
+        "temperature_setting": 37,
+        "current_temperature": 36,
+        "temperature_unit": 1,
+        "wave_state": 100,
+    }
+    normalized = aws_api._normalize_state(aws_state)
+
+    # Power fields
+    assert normalized["power"] is True
+    assert normalized["heat"] == 0
+
+    # Temperature fields
+    assert normalized["temp_set"] == 37
+    assert normalized["temp_now"] == 36
+    assert normalized["temp_set_unit"] == 1
+
+    # Wave field
+    assert normalized["wave"] == 100
+
+
+def test_normalize_state_filter(aws_api):
+    """Test filter_state normalization (2=ON)."""
+    # Filter on
+    aws_state = {"filter_state": 2}
+    normalized = aws_api._normalize_state(aws_state)
+    assert normalized["filter_power"] is True
+
+    # Filter off
+    aws_state = {"filter_state": 0}
+    normalized = aws_api._normalize_state(aws_state)
+    assert normalized["filter_power"] is False
+
+
+def test_normalize_state_unmapped_fields(aws_api):
+    """Test unmapped fields are preserved with aws_ prefix."""
+    aws_state = {"power_state": 1, "unknown_field": 42, "debug_info": "test"}
+    normalized = aws_api._normalize_state(aws_state)
+
+    assert normalized["power"] is True
+    assert normalized["aws_unknown_field"] == 42
+    assert normalized["aws_debug_info"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_returns_results(aws_api, mock_session):
+    """Test fetch_data returns BestwayApiResults."""
+    # Setup device
+    aws_api.refresh_bindings = AsyncMock()
+    aws_api.devices = {
+        "device1": MagicMock(
+            device_id="device1",
+            product_name="AIRJET",
+        )
+    }
+
+    # Mock shadow response with context manager support
+    shadow_response = create_mock_response(
+        200,
+        {
+            "data": {
+                "shadow": {
+                    "state": {
+                        "reported": {
+                            "power_state": 1,
+                            "heater_state": 3,
+                            "temperature_setting": 37,
+                            "current_temperature": 36,
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+    mock_session.get = MagicMock(return_value=shadow_response)
+
+    # Execute
+    results = await aws_api.fetch_data()
+
+    # Verify structure
+    assert hasattr(results, "devices")
+    assert "device1" in results.devices
+
+    status = results.devices["device1"]
+    assert status.attrs["power"] is True
+    assert status.attrs["heat"] == 3
+    assert status.attrs["temp_set"] == 37
+    assert status.attrs["temp_now"] == 36
+
+
+@pytest.mark.asyncio
+async def test_set_device_state_sends_command(aws_api, mock_session):
+    """Test control command sends encrypted payload."""
+    # Setup device
+    aws_api.devices = {
+        "device1": MagicMock(device_id="device1", product_name="AIRJET")
+    }
+    aws_api._state_cache = {"device1": MagicMock(attrs={})}
+
+    # Mock POST response with context manager support
+    post_response = create_mock_response(200, {"code": 0})
+
+    mock_session.post = MagicMock(return_value=post_response)
+
+    # Execute
+    success = await aws_api.set_device_state("device1", {"power": True})
+
+    # Verify
+    assert success is True
+    assert mock_session.post.called
+
+
+@pytest.mark.asyncio
+async def test_do_get_handles_401(aws_api, mock_session):
+    """Test _do_get raises AwsIotAuthException on HTTP 401."""
+    response = create_mock_response(401, {})
+
+    mock_session.get = MagicMock(return_value=response)
+
+    with pytest.raises(AwsIotAuthException):
+        await aws_api._do_get("/test")

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -1,13 +1,12 @@
 """Tests for AWS IoT API client."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.bestway.aws_iot.api import (
     AwsIotApi,
     AwsIotAuthException,
 )
-from custom_components.bestway.bestway.model import BestwayDeviceType
 
 
 def create_mock_response(status: int, json_data: dict):
@@ -75,25 +74,26 @@ def test_signature_different_for_different_inputs(aws_api):
 @pytest.mark.asyncio
 async def test_refresh_bindings_discovers_devices(aws_api, mock_session):
     """Test device discovery populates devices dict."""
-    # Mock API responses with context manager support
-    homes_response = create_mock_response(200, {"list": [{"home_id": "home1"}]})
-    rooms_response = create_mock_response(200, {"list": [{"room_id": "room1"}]})
-    devices_response = create_mock_response(
-        200,
-        {
+    # Patch _do_get to return properly structured API responses
+    homes_data = {"code": 0, "data": {"list": [{"id": "home1", "name": "My Home"}]}}
+    rooms_data = {"code": 0, "data": {"list": [{"id": "room1", "name": "Garden"}]}}
+    devices_data = {
+        "code": 0,
+        "data": {
             "list": [
                 {
                     "device_id": "device123",
                     "device_alias": "Test Spa",
                     "product_series": "AIRJET",
+                    "product_id": "T53NN8",
                     "service_region": "eu-central-1",
                     "is_online": True,
                 }
             ]
         },
-    )
+    }
 
-    mock_session.get = MagicMock(side_effect=[homes_response, rooms_response, devices_response])
+    aws_api._do_get = AsyncMock(side_effect=[homes_data, rooms_data, devices_data])
 
     # Execute
     await aws_api.refresh_bindings()
@@ -114,39 +114,47 @@ async def test_refresh_bindings_discovers_devices(aws_api, mock_session):
 async def test_refresh_bindings_multiple_devices(aws_api, mock_session):
     """Test discovery of multiple devices across rooms."""
     # 1 home, 2 rooms, 1 device per room
-    homes_response = create_mock_response(200, {"list": [{"home_id": "home1"}]})
-    rooms_response = create_mock_response(
-        200, {"list": [{"room_id": "room1"}, {"room_id": "room2"}]}
-    )
-    devices1_response = create_mock_response(
-        200,
-        {
+    homes_data = {"code": 0, "data": {"list": [{"id": "home1", "name": "My Home"}]}}
+    rooms_data = {
+        "code": 0,
+        "data": {
+            "list": [
+                {"id": "room1", "name": "Garden"},
+                {"id": "room2", "name": "Patio"},
+            ]
+        },
+    }
+    devices1_data = {
+        "code": 0,
+        "data": {
             "list": [
                 {
                     "device_id": "device1",
                     "device_alias": "Spa 1",
                     "product_series": "AIRJET",
+                    "product_id": "T53NN8",
                     "service_region": "eu-central-1",
                 }
             ]
         },
-    )
-    devices2_response = create_mock_response(
-        200,
-        {
+    }
+    devices2_data = {
+        "code": 0,
+        "data": {
             "list": [
                 {
                     "device_id": "device2",
                     "device_alias": "Spa 2",
                     "product_series": "HYDROJET",
+                    "product_id": "T53NN9",
                     "service_region": "us-east-1",
                 }
             ]
         },
-    )
+    }
 
-    mock_session.get = MagicMock(
-        side_effect=[homes_response, rooms_response, devices1_response, devices2_response]
+    aws_api._do_get = AsyncMock(
+        side_effect=[homes_data, rooms_data, devices1_data, devices2_data]
     )
 
     await aws_api.refresh_bindings()
@@ -240,35 +248,40 @@ def test_normalize_state_wave_mapping():
 @pytest.mark.asyncio
 async def test_fetch_data_returns_results(aws_api, mock_session):
     """Test fetch_data returns BestwayApiResults."""
-    # Setup device
-    aws_api.refresh_bindings = AsyncMock()
+    from custom_components.bestway.bestway.model import BestwayDevice
+
+    # Setup device with real attributes (not MagicMock) so JSON serialization works
     aws_api.devices = {
-        "device1": MagicMock(
+        "device1": BestwayDevice(
+            protocol_version=2,
             device_id="device1",
             product_name="AIRJET",
+            alias="Test Spa",
+            mcu_soft_version="unknown",
+            mcu_hard_version="unknown",
+            wifi_soft_version="unknown",
+            wifi_hard_version="unknown",
+            is_online=True,
+            backend="aws_iot",
+            product_id="T53NN8",
         )
     }
 
-    # Mock shadow response with context manager support
-    shadow_response = create_mock_response(
-        200,
-        {
-            "data": {
-                "shadow": {
-                    "state": {
-                        "reported": {
-                            "power_state": 1,
-                            "heater_state": 3,
-                            "temperature_setting": 37,
-                            "current_temperature": 36,
-                        }
-                    }
+    # Patch _do_post to return properly structured shadow response
+    shadow_data = {
+        "code": 0,
+        "data": {
+            "state": {
+                "reported": {
+                    "power_state": 1,
+                    "heater_state": 3,
+                    "temperature_setting": 37,
+                    "water_temperature": 36,
                 }
             }
         },
-    )
-
-    mock_session.get = MagicMock(return_value=shadow_response)
+    }
+    aws_api._do_post = AsyncMock(return_value=shadow_data)
 
     # Execute
     results = await aws_api.fetch_data()
@@ -287,19 +300,31 @@ async def test_fetch_data_returns_results(aws_api, mock_session):
 @pytest.mark.asyncio
 async def test_set_device_state_sends_command(aws_api, mock_session):
     """Test control command sends encrypted payload."""
-    # Setup device
+    from custom_components.bestway.bestway.model import BestwayDevice
+
+    # Setup device with real attributes for JSON serialization
     aws_api.devices = {
-        "device1": MagicMock(device_id="device1", product_name="AIRJET")
+        "device1": BestwayDevice(
+            protocol_version=2,
+            device_id="device1",
+            product_name="AIRJET",
+            alias="Test Spa",
+            mcu_soft_version="unknown",
+            mcu_hard_version="unknown",
+            wifi_soft_version="unknown",
+            wifi_hard_version="unknown",
+            is_online=True,
+            backend="aws_iot",
+            product_id="T53NN8",
+        )
     }
-    aws_api._state_cache = {"device1": MagicMock(attrs={})}
 
-    # Mock POST response with context manager support
-    post_response = create_mock_response(200, {"code": 0})
-
-    mock_session.post = MagicMock(return_value=post_response)
+    # Mock the v2 POST to succeed
+    v2_response = create_mock_response(200, {"code": 0})
+    mock_session.post = MagicMock(return_value=v2_response)
 
     # Execute
-    success = await aws_api.set_device_state("device1", {"power": True})
+    success = await aws_api.set_device_state("device1", {"power_state": True})
 
     # Verify
     assert success is True

--- a/tests/test_aws_iot_encryption.py
+++ b/tests/test_aws_iot_encryption.py
@@ -1,0 +1,180 @@
+"""Tests for AWS IoT encryption module."""
+
+import json
+import pytest
+
+from custom_components.bestway.aws_iot.encryption import (
+    FIXED_IV,
+    decrypt_command_payload,
+    encrypt_command_payload,
+)
+
+
+def test_encrypt_decrypt_round_trip():
+    """Test basic encryption and decryption round-trip."""
+    data = {"device_id": "test123", "command": {"power": 1}}
+    sign = "C4C0283EF2420F03624068553CC8783C"
+    app_secret = "4ECvVs13enL5AiYSmscNjvlaisklQDz7vWPCCWXcEFjhWfTmLT"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+    decrypted_str = decrypt_command_payload(sign, app_secret, encrypted)
+    decrypted = json.loads(decrypted_str)
+
+    assert decrypted == data
+
+
+def test_encrypt_different_signs_different_output():
+    """Verify different signatures produce different encrypted outputs."""
+    data = {"test": "value"}
+    app_secret = "secret"
+
+    plaintext = json.dumps(data)
+    encrypted1 = encrypt_command_payload("SIGN1" * 6, app_secret, plaintext)
+    encrypted2 = encrypt_command_payload("SIGN2" * 6, app_secret, plaintext)
+
+    # Same data, different signs → different ciphertext
+    assert encrypted1 != encrypted2
+
+
+def test_encrypt_different_secrets_different_output():
+    """Verify different app secrets produce different encrypted outputs."""
+    data = {"test": "value"}
+    sign = "A" * 32
+
+    plaintext = json.dumps(data)
+    encrypted1 = encrypt_command_payload(sign, "secret1", plaintext)
+    encrypted2 = encrypt_command_payload(sign, "secret2", plaintext)
+
+    # Same data+sign, different secrets → different ciphertext
+    assert encrypted1 != encrypted2
+
+
+def test_encrypt_complex_nested_data():
+    """Test encryption of complex nested command structure."""
+    data = {
+        "device_id": "f294cdeece1e11f0abb45925c07ce073",
+        "product_id": "T53NN8",
+        "command": {
+            "power_state": 1,
+            "heater_state": 3,
+            "temperature_setting": 37,
+            "wave_state": 100,
+        },
+    }
+    sign = "B" * 32
+    app_secret = "test_secret_123"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+    decrypted_str = decrypt_command_payload(sign, app_secret, encrypted)
+    decrypted = json.loads(decrypted_str)
+
+    assert decrypted == data
+    assert decrypted["command"]["power_state"] == 1
+    assert decrypted["command"]["temperature_setting"] == 37
+
+
+def test_encrypt_unicode_characters():
+    """Test encryption handles Unicode characters correctly."""
+    data = {"device_name": "Tubby™ Spa", "location": "Köln"}
+    sign = "C" * 32
+    app_secret = "secret"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+    decrypted_str = decrypt_command_payload(sign, app_secret, encrypted)
+    decrypted = json.loads(decrypted_str)
+
+    assert decrypted == data
+    assert decrypted["device_name"] == "Tubby™ Spa"
+
+
+def test_encrypt_empty_command():
+    """Test encryption of minimal/empty command."""
+    data = {}
+    sign = "D" * 32
+    app_secret = "secret"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+    decrypted_str = decrypt_command_payload(sign, app_secret, encrypted)
+    decrypted = json.loads(decrypted_str)
+
+    assert decrypted == data
+
+
+def test_encrypt_large_payload():
+    """Test encryption of large command payload (>1KB)."""
+    data = {"items": [f"item_{i}" for i in range(100)]}
+    sign = "E" * 32
+    app_secret = "secret"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+    decrypted_str = decrypt_command_payload(sign, app_secret, encrypted)
+    decrypted = json.loads(decrypted_str)
+
+    assert decrypted == data
+    assert len(decrypted["items"]) == 100
+
+
+def test_decrypt_with_wrong_sign_fails():
+    """Verify decryption fails with wrong signature."""
+    data = {"test": "value"}
+    sign = "F" * 32
+    app_secret = "secret"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+
+    # Try to decrypt with different sign
+    with pytest.raises(Exception):  # ValueError or padding error
+        decrypt_command_payload("WRONG" * 6, app_secret, encrypted)
+
+
+def test_decrypt_with_wrong_secret_fails():
+    """Verify decryption fails with wrong app secret."""
+    data = {"test": "value"}
+    sign = "G" * 32
+    app_secret = "secret"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+
+    # Try to decrypt with different secret
+    with pytest.raises(Exception):  # ValueError or padding error
+        decrypt_command_payload(sign, "wrong_secret", encrypted)
+
+
+def test_decrypt_invalid_base64_fails():
+    """Verify decryption fails with invalid base64 input."""
+    sign = "H" * 32
+    app_secret = "secret"
+
+    with pytest.raises(Exception):  # Base64 decode error
+        decrypt_command_payload(sign, app_secret, "not-valid-base64!!!")
+
+
+def test_encrypt_known_test_vector():
+    """Validate encryption against known working example from APK analysis.
+
+    This test uses a captured command from the official app to verify our
+    implementation produces compatible encrypted payloads.
+    """
+    # Test vector from New_bestway_spa implementation
+    data = {"device_id": "abc", "product_id": "T53NN8", "command": {"power": 1}}
+    sign = "C4C0283EF2420F03624068553CC8783C"
+    app_secret = "4ECvVs13enL5AiYSmscNjvlaisklQDz7vWPCCWXcEFjhWfTmLT"
+
+    plaintext = json.dumps(data)
+    encrypted = encrypt_command_payload(sign, app_secret, plaintext)
+
+    # Verify format
+    assert encrypted.startswith("OG46qEz")  # Fixed IV in base64
+    assert len(encrypted) > 50  # Should be substantial length
+
+    # Verify round-trip
+    decrypted_str = decrypt_command_payload(sign, app_secret, encrypted)
+    decrypted = json.loads(decrypted_str)
+    assert decrypted == data

--- a/tests/test_aws_iot_encryption.py
+++ b/tests/test_aws_iot_encryption.py
@@ -4,7 +4,6 @@ import json
 import pytest
 
 from custom_components.bestway.aws_iot.encryption import (
-    FIXED_IV,
     decrypt_command_payload,
     encrypt_command_payload,
 )

--- a/tests/test_aws_iot_model.py
+++ b/tests/test_aws_iot_model.py
@@ -5,15 +5,30 @@ from custom_components.bestway.bestway.model import BestwayDevice, BestwayDevice
 
 def test_from_aws_product_series_mappings():
     """Test V02 product series to device type mappings."""
-    assert BestwayDeviceType.from_aws_product_series("AIRJET") == BestwayDeviceType.AIRJET_V02
-    assert BestwayDeviceType.from_aws_product_series("ULTRAFIT_AIRJET") == BestwayDeviceType.ULTRAFIT_AIRJET_V02
-    assert BestwayDeviceType.from_aws_product_series("HYDROJET") == BestwayDeviceType.HYDROJET_V02
-    assert BestwayDeviceType.from_aws_product_series("HYDROJET_PRO") == BestwayDeviceType.HYDROJET_PRO_V02
+    assert (
+        BestwayDeviceType.from_aws_product_series("AIRJET")
+        == BestwayDeviceType.AIRJET_V02
+    )
+    assert (
+        BestwayDeviceType.from_aws_product_series("ULTRAFIT_AIRJET")
+        == BestwayDeviceType.ULTRAFIT_AIRJET_V02
+    )
+    assert (
+        BestwayDeviceType.from_aws_product_series("HYDROJET")
+        == BestwayDeviceType.HYDROJET_V02
+    )
+    assert (
+        BestwayDeviceType.from_aws_product_series("HYDROJET_PRO")
+        == BestwayDeviceType.HYDROJET_PRO_V02
+    )
 
 
 def test_from_aws_product_series_unknown():
     """Test unknown and empty product series return UNKNOWN."""
-    assert BestwayDeviceType.from_aws_product_series("UNKNOWN_SERIES") == BestwayDeviceType.UNKNOWN
+    assert (
+        BestwayDeviceType.from_aws_product_series("UNKNOWN_SERIES")
+        == BestwayDeviceType.UNKNOWN
+    )
     assert BestwayDeviceType.from_aws_product_series("") == BestwayDeviceType.UNKNOWN
 
 

--- a/tests/test_aws_iot_model.py
+++ b/tests/test_aws_iot_model.py
@@ -1,0 +1,70 @@
+"""Tests for AWS IoT model extensions."""
+
+from custom_components.bestway.bestway.model import BestwayDevice, BestwayDeviceType
+
+
+def test_from_aws_product_series_mappings():
+    """Test V02 product series to device type mappings."""
+    assert BestwayDeviceType.from_aws_product_series("AIRJET") == BestwayDeviceType.AIRJET_V02
+    assert BestwayDeviceType.from_aws_product_series("ULTRAFIT_AIRJET") == BestwayDeviceType.ULTRAFIT_AIRJET_V02
+    assert BestwayDeviceType.from_aws_product_series("HYDROJET") == BestwayDeviceType.HYDROJET_V02
+    assert BestwayDeviceType.from_aws_product_series("HYDROJET_PRO") == BestwayDeviceType.HYDROJET_PRO_V02
+
+
+def test_from_aws_product_series_unknown():
+    """Test unknown and empty product series return UNKNOWN."""
+    assert BestwayDeviceType.from_aws_product_series("UNKNOWN_SERIES") == BestwayDeviceType.UNKNOWN
+    assert BestwayDeviceType.from_aws_product_series("") == BestwayDeviceType.UNKNOWN
+
+
+def test_bestway_device_backend_default_gizwits():
+    """Test BestwayDevice backend field defaults to 'gizwits'."""
+    device = BestwayDevice(
+        protocol_version=1,
+        device_id="test123",
+        product_name="Airjet",
+        alias="Test Spa",
+        mcu_soft_version="1.0",
+        mcu_hard_version="1.0",
+        wifi_soft_version="1.0",
+        wifi_hard_version="1.0",
+        is_online=True,
+    )
+    assert device.backend == "gizwits"
+
+
+def test_bestway_device_backend_aws_iot():
+    """Test BestwayDevice with AWS IoT backend."""
+    device = BestwayDevice(
+        protocol_version=1,
+        device_id="test123",
+        product_name="AIRJET",
+        alias="Test Spa",
+        mcu_soft_version="1.0",
+        mcu_hard_version="1.0",
+        wifi_soft_version="1.0",
+        wifi_hard_version="1.0",
+        is_online=True,
+        backend="aws_iot",
+    )
+    assert device.backend == "aws_iot"
+
+
+def test_from_api_product_name_still_works():
+    """Verify existing Gizwits product name mapping unchanged."""
+    assert (
+        BestwayDeviceType.from_api_product_name("Airjet")
+        == BestwayDeviceType.AIRJET_SPA
+    )
+    assert (
+        BestwayDeviceType.from_api_product_name("Airjet_V01")
+        == BestwayDeviceType.AIRJET_V01_SPA
+    )
+    assert (
+        BestwayDeviceType.from_api_product_name("Hydrojet")
+        == BestwayDeviceType.HYDROJET_SPA
+    )
+    assert (
+        BestwayDeviceType.from_api_product_name("Hydrojet_Pro")
+        == BestwayDeviceType.HYDROJET_PRO_SPA
+    )

--- a/tests/test_aws_iot_websocket.py
+++ b/tests/test_aws_iot_websocket.py
@@ -58,8 +58,8 @@ async def test_handle_message_calls_callback_with_normalized_attrs(aws_websocket
         }
     }
 
-    with patch("custom_components.bestway.aws_iot.api.AwsIotApi._normalize_state") as mock_normalize:
-        mock_normalize.return_value = {"power": True, "heat": 3, "temp_set": 37}
+    with patch("custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state") as mock_normalize:
+        mock_normalize.return_value = {"power": True, "heat": 3, "Tset": 37}
 
         await aws_websocket._handle_message(message)
 
@@ -67,7 +67,7 @@ async def test_handle_message_calls_callback_with_normalized_attrs(aws_websocket
         mock_callback.assert_called_once()
         call_args = mock_callback.call_args[0]
         assert call_args[0] == "test_device_123"  # device_id
-        assert call_args[1] == {"power": True, "heat": 3, "temp_set": 37}  # normalized
+        assert call_args[1] == {"power": True, "heat": 3, "Tset": 37}  # normalized
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_handle_message_no_callback_error(aws_websocket):
     message = {"state": {"reported": {"power_state": 1}}}
 
     # Should not raise exception
-    with patch("custom_components.bestway.aws_iot.api.AwsIotApi._normalize_state"):
+    with patch("custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state"):
         await aws_websocket._handle_message(message)
 
 
@@ -203,7 +203,7 @@ async def test_listen_loop_processes_shadow_updates(aws_websocket):
     mock_ws.__aiter__ = lambda self: message_generator()
     aws_websocket._websocket = mock_ws
 
-    with patch("custom_components.bestway.aws_iot.api.AwsIotApi._normalize_state") as mock_normalize:
+    with patch("custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state") as mock_normalize:
         mock_normalize.side_effect = [
             {"power": True},
             {"heat": 3},

--- a/tests/test_aws_iot_websocket.py
+++ b/tests/test_aws_iot_websocket.py
@@ -1,0 +1,238 @@
+"""Tests for AWS IoT WebSocket client."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from custom_components.bestway.aws_iot.websocket import AwsIotWebSocket
+
+
+@pytest.fixture
+def mock_callback():
+    """Create mock coordinator callback."""
+    return MagicMock()
+
+
+@pytest.fixture
+def aws_websocket(mock_callback):
+    """Create AwsIotWebSocket instance."""
+    return AwsIotWebSocket(
+        device_id="test_device_123",
+        service_region="eu-central-1",
+        token="test_token",
+        update_callback=mock_callback,
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_calls_websockets_with_auth_header(aws_websocket):
+    """Test connect uses Authorization header."""
+    with patch("websockets.connect") as mock_connect, \
+         patch("homeassistant.util.ssl.get_default_context"), \
+         patch.object(aws_websocket, "_listen_loop", return_value=None), \
+         patch.object(aws_websocket, "_heartbeat_loop", return_value=None):
+
+        mock_connect.return_value = AsyncMock()
+
+        await aws_websocket.connect()
+
+        # Verify Authorization header was passed
+        call_kwargs = mock_connect.call_args.kwargs
+        assert "additional_headers" in call_kwargs
+        assert call_kwargs["additional_headers"]["Authorization"] == "test_token"
+        assert aws_websocket._reconnect_count == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_message_calls_callback_with_normalized_attrs(aws_websocket, mock_callback):
+    """Test shadow delta message triggers callback with normalized fields."""
+    # Shadow delta message from AWS IoT
+    message = {
+        "state": {
+            "reported": {
+                "power_state": 1,
+                "heater_state": 3,
+                "temperature_setting": 37,
+            }
+        }
+    }
+
+    with patch("custom_components.bestway.aws_iot.api.AwsIotApi._normalize_state") as mock_normalize:
+        mock_normalize.return_value = {"power": True, "heat": 3, "temp_set": 37}
+
+        await aws_websocket._handle_message(message)
+
+        # Verify callback was called with device_id and normalized attrs
+        mock_callback.assert_called_once()
+        call_args = mock_callback.call_args[0]
+        assert call_args[0] == "test_device_123"  # device_id
+        assert call_args[1] == {"power": True, "heat": 3, "temp_set": 37}  # normalized
+
+
+@pytest.mark.asyncio
+async def test_handle_message_no_callback_error(aws_websocket):
+    """Test message handling with missing callback doesn't crash."""
+    aws_websocket._update_callback = None
+    message = {"state": {"reported": {"power_state": 1}}}
+
+    # Should not raise exception
+    with patch("custom_components.bestway.aws_iot.api.AwsIotApi._normalize_state"):
+        await aws_websocket._handle_message(message)
+
+
+@pytest.mark.asyncio
+async def test_http_400_triggers_token_refresh(aws_websocket):
+    """Test HTTP 400 error triggers token refresh and immediate retry."""
+    token_refresh = AsyncMock(return_value="new_token_789")
+    aws_websocket._token_refresh_callback = token_refresh
+
+    with patch("custom_components.bestway.aws_iot.websocket.websockets.connect") as mock_connect:
+        # First call fails with HTTP 400, second succeeds
+        mock_connect.side_effect = [
+            Exception("HTTP 400 Bad Request"),
+            AsyncMock(),  # Success on second call
+        ]
+
+        await aws_websocket.connect()
+
+        # Verify token refresh was called
+        token_refresh.assert_called_once()
+        assert aws_websocket._token == "new_token_789"
+        # Should have retried (2 connect attempts)
+        assert mock_connect.call_count == 2
+        # Reconnect count should still be 0 (immediate retry, no backoff)
+        assert aws_websocket._reconnect_count == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_stops_running(aws_websocket):
+    """Test disconnect stops the running flag and closes WebSocket."""
+    mock_ws = AsyncMock()
+    aws_websocket._websocket = mock_ws
+    aws_websocket._running = True
+    # No tasks to avoid await complexity in tests
+
+    await aws_websocket.disconnect()
+
+    assert aws_websocket._running is False
+    assert mock_ws.close.called
+    assert aws_websocket._websocket is None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_uses_exponential_backoff(aws_websocket):
+    """Test reconnection delay increases with each attempt."""
+    aws_websocket._running = True
+
+    with patch("custom_components.bestway.aws_iot.websocket.asyncio.sleep") as mock_sleep, \
+         patch.object(aws_websocket, "connect", new_callable=AsyncMock):
+
+        # First reconnect (delay = 3s)
+        aws_websocket._reconnect_count = 0
+        await aws_websocket._schedule_reconnect()
+        mock_sleep.assert_called_with(3)
+        assert aws_websocket._reconnect_count == 1
+
+        # Second reconnect (delay = 6s)
+        await aws_websocket._schedule_reconnect()
+        mock_sleep.assert_called_with(6)
+        assert aws_websocket._reconnect_count == 2
+
+
+@pytest.mark.asyncio
+async def test_region_fallback_to_eu(aws_websocket):
+    """Test unknown region falls back to EU endpoint."""
+    aws_websocket._service_region = "unknown-region-99"
+
+    url = aws_websocket.ws_url
+
+    # Should use EU endpoint as fallback
+    assert "eu-central-1" in url
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_sends_messages(aws_websocket):
+    """Test heartbeat loop sends JSON heartbeat and WebSocket ping."""
+    mock_ws = MagicMock()
+    mock_ws.send = AsyncMock()
+    mock_ws.ping = AsyncMock()
+
+    aws_websocket._websocket = mock_ws
+    aws_websocket._running = True
+
+    # Mock asyncio.sleep to run one iteration then cancel
+    with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        mock_sleep.side_effect = [None, asyncio.CancelledError()]
+
+        try:
+            await aws_websocket._heartbeat_loop()
+        except asyncio.CancelledError:
+            pass
+
+        # Verify both heartbeat messages sent
+        assert mock_ws.send.called
+        assert mock_ws.ping.called
+
+        # Verify JSON heartbeat format
+        heartbeat_msg = json.loads(mock_ws.send.call_args[0][0])
+        assert heartbeat_msg["action"] == "heartbeat"
+        assert heartbeat_msg["req_event"] == "heartbeat_req"
+        assert "seq_id" in heartbeat_msg
+
+
+@pytest.mark.asyncio
+async def test_listen_loop_processes_shadow_updates(aws_websocket):
+    """Test listen loop processes incoming shadow delta messages."""
+    updates_received = []
+
+    def capture_callback(device_id, attrs):
+        updates_received.append((device_id, attrs))
+
+    aws_websocket._update_callback = capture_callback
+
+    # Mock WebSocket to yield messages
+    mock_ws = MagicMock()
+    message1 = json.dumps({"state": {"reported": {"power_state": 1}}})
+    message2 = json.dumps({"state": {"reported": {"heater_state": 3}}})
+
+    async def message_generator():
+        yield message1
+        yield message2
+
+    mock_ws.__aiter__ = lambda self: message_generator()
+    aws_websocket._websocket = mock_ws
+
+    with patch("custom_components.bestway.aws_iot.api.AwsIotApi._normalize_state") as mock_normalize:
+        mock_normalize.side_effect = [
+            {"power": True},
+            {"heat": 3},
+        ]
+
+        await aws_websocket._listen_loop()
+
+        # Verify both messages processed
+        assert len(updates_received) == 2
+        assert updates_received[0] == ("test_device_123", {"power": True})
+        assert updates_received[1] == ("test_device_123", {"heat": 3})
+
+
+@pytest.mark.asyncio
+async def test_connection_closed_triggers_reconnect(aws_websocket):
+    """Test listen loop handles connection closure."""
+    from websockets.exceptions import ConnectionClosed
+
+    mock_ws = AsyncMock()
+    mock_ws.__aiter__.return_value = iter([])  # Empty iterator
+
+    aws_websocket._websocket = mock_ws
+    aws_websocket._running = True
+
+    with patch.object(aws_websocket, "_schedule_reconnect", new_callable=AsyncMock) as mock_reconnect:
+        # Simulate connection closed by raising exception
+        mock_ws.__aiter__.side_effect = ConnectionClosed(None, None)
+
+        await aws_websocket._listen_loop()
+
+        # Should have scheduled reconnect
+        mock_reconnect.assert_called_once()

--- a/tests/test_aws_iot_websocket.py
+++ b/tests/test_aws_iot_websocket.py
@@ -28,11 +28,12 @@ def aws_websocket(mock_callback):
 @pytest.mark.asyncio
 async def test_connect_calls_websockets_with_auth_header(aws_websocket):
     """Test connect uses Authorization header."""
-    with patch("websockets.connect") as mock_connect, \
-         patch("homeassistant.util.ssl.get_default_context"), \
-         patch.object(aws_websocket, "_listen_loop", return_value=None), \
-         patch.object(aws_websocket, "_heartbeat_loop", return_value=None):
-
+    with (
+        patch("websockets.connect") as mock_connect,
+        patch("homeassistant.util.ssl.get_default_context"),
+        patch.object(aws_websocket, "_listen_loop", return_value=None),
+        patch.object(aws_websocket, "_heartbeat_loop", return_value=None),
+    ):
         mock_connect.return_value = AsyncMock()
 
         await aws_websocket.connect()
@@ -45,7 +46,9 @@ async def test_connect_calls_websockets_with_auth_header(aws_websocket):
 
 
 @pytest.mark.asyncio
-async def test_handle_message_calls_callback_with_normalized_attrs(aws_websocket, mock_callback):
+async def test_handle_message_calls_callback_with_normalized_attrs(
+    aws_websocket, mock_callback
+):
     """Test shadow delta message triggers callback with normalized fields."""
     # Shadow delta message from AWS IoT
     message = {
@@ -58,7 +61,9 @@ async def test_handle_message_calls_callback_with_normalized_attrs(aws_websocket
         }
     }
 
-    with patch("custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state") as mock_normalize:
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state"
+    ) as mock_normalize:
         mock_normalize.return_value = {"power": True, "heat": 3, "Tset": 37}
 
         await aws_websocket._handle_message(message)
@@ -87,7 +92,9 @@ async def test_http_400_triggers_token_refresh(aws_websocket):
     token_refresh = AsyncMock(return_value="new_token_789")
     aws_websocket._token_refresh_callback = token_refresh
 
-    with patch("custom_components.bestway.aws_iot.websocket.websockets.connect") as mock_connect:
+    with patch(
+        "custom_components.bestway.aws_iot.websocket.websockets.connect"
+    ) as mock_connect:
         # First call fails with HTTP 400, second succeeds
         mock_connect.side_effect = [
             Exception("HTTP 400 Bad Request"),
@@ -125,9 +132,12 @@ async def test_reconnect_uses_exponential_backoff(aws_websocket):
     """Test reconnection delay increases with each attempt."""
     aws_websocket._running = True
 
-    with patch("custom_components.bestway.aws_iot.websocket.asyncio.sleep") as mock_sleep, \
-         patch.object(aws_websocket, "connect", new_callable=AsyncMock):
-
+    with (
+        patch(
+            "custom_components.bestway.aws_iot.websocket.asyncio.sleep"
+        ) as mock_sleep,
+        patch.object(aws_websocket, "connect", new_callable=AsyncMock),
+    ):
         # First reconnect (delay = 3s)
         aws_websocket._reconnect_count = 0
         await aws_websocket._schedule_reconnect()
@@ -203,7 +213,9 @@ async def test_listen_loop_processes_shadow_updates(aws_websocket):
     mock_ws.__aiter__ = lambda self: message_generator()
     aws_websocket._websocket = mock_ws
 
-    with patch("custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state") as mock_normalize:
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state"
+    ) as mock_normalize:
         mock_normalize.side_effect = [
             {"power": True},
             {"heat": 3},
@@ -228,7 +240,9 @@ async def test_connection_closed_triggers_reconnect(aws_websocket):
     aws_websocket._websocket = mock_ws
     aws_websocket._running = True
 
-    with patch.object(aws_websocket, "_schedule_reconnect", new_callable=AsyncMock) as mock_reconnect:
+    with patch.object(
+        aws_websocket, "_schedule_reconnect", new_callable=AsyncMock
+    ) as mock_reconnect:
         # Simulate connection closed by raising exception
         mock_ws.__aiter__.side_effect = ConnectionClosed(None, None)
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test bestway config flow."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
@@ -11,9 +11,7 @@ from custom_components.bestway.const import (
     CONF_API_ROOT,
     CONF_API_ROOT_EU,
     CONF_PASSWORD,
-    CONF_UID,
     CONF_USER_TOKEN,
-    CONF_USER_TOKEN_EXPIRY,
     CONF_USERNAME,
     DOMAIN,
 )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test bestway config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
@@ -39,17 +39,26 @@ def bypass_setup_fixture():
         yield
 
 
-# Simiulate a successful config flow.
+# Simulate a successful Gizwits config flow.
 async def test_successful_config_flow(hass, bypass_get_data):
-    """Test a successful config flow."""
+    """Test a successful Gizwits (V01) config flow."""
     # Initialize a config flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    # Check that the config flow shows the user form as the first step
+    # Check that the config flow shows backend selection as first step
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
+
+    # Select Gizwits backend
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "gizwits"}
+    )
+
+    # Check that we're routed to Gizwits auth
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "gizwits_auth"
 
     # Mock an authentication call that provides a token to keep hold of
     token = BestwayUserToken("foo", "t0k3n", 123)
@@ -61,22 +70,18 @@ async def test_successful_config_flow(hass, bypass_get_data):
             result["flow_id"], user_input=MOCK_USER_INPUT
         )
 
-    expected_output = dict(MOCK_USER_INPUT)
-    expected_output[CONF_UID] = token.user_id
-    expected_output[CONF_USER_TOKEN] = token.user_token
-    expected_output[CONF_USER_TOKEN_EXPIRY] = token.expiry
-
-    # Check that the config flow is complete and a new entry is created with
-    # the input data
+    # Verify entry created with correct data
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == MOCK_USER_INPUT[CONF_USERNAME]
-    assert result["data"] == expected_output
+    assert result["data"]["backend"] == "gizwits"
+    assert result["data"][CONF_USER_TOKEN] == token.user_token
+    assert result["data"][CONF_USERNAME] == MOCK_USER_INPUT[CONF_USERNAME]
     assert result["result"]
 
 
 # Simulate an exception during the authentication process
 async def test_failed_config_flow(hass, error_on_auth):
-    """Test a failed config flow due to credential validation failure."""
+    """Test a failed Gizwits config flow due to credential validation failure."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -84,9 +89,96 @@ async def test_failed_config_flow(hass, error_on_auth):
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
+    # Select Gizwits backend
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "gizwits"}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "gizwits_auth"
+
+    # Try to authenticate with credentials (will fail due to error_on_auth fixture)
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=MOCK_USER_INPUT
     )
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "unknown_connection_error"}
+
+
+async def test_aws_iot_config_flow_routing(hass):
+    """Test AWS IoT (V02) routing to auth step."""
+    # Initialize config flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Check backend selection shown
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Select AWS IoT backend
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "aws_iot"}
+    )
+
+    # Check routed to AWS IoT auth with QR and visitor_id options
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "aws_iot_auth"
+
+
+async def test_aws_iot_auth_requires_qr_or_visitor(hass):
+    """Test AWS IoT auth requires either QR or visitor_id."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Select AWS IoT
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "aws_iot"}
+    )
+
+    # Submit with neither QR nor visitor_id
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={},
+    )
+
+    # Should show error
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["base"] == "qr_or_visitor_required"
+
+
+async def test_aws_iot_qr_validation(hass):
+    """Test QR code format validation."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # Select AWS IoT
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "aws_iot"}
+    )
+
+    # Submit invalid QR
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"qr_code": "INVALID_QR_123"},
+    )
+
+    # Should show QR format error
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["qr_code"] == "invalid_qr_format"
+
+
+async def test_backend_selection_shows_both_options(hass):
+    """Test backend selection displays both V01 and V02 options."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    # Schema should have backend field with options
+    schema_keys = list(result["data_schema"].schema.keys())
+    assert any("backend" in str(key) for key in schema_keys)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -37,7 +37,7 @@ async def test_setup_unload_and_reload_entry(hass: HomeAssistant, bypass_get_dat
             CONF_API_ROOT: CONF_API_ROOT_EU,
             CONF_USER_TOKEN: "t0k3n",
             CONF_USER_TOKEN_EXPIRY: int(future),
-            CONF_UID: "uid",
+            CONF_UID: "test_uid_123",  # Required to prevent token refresh
         },
         version=2,
         entry_id="test",


### PR DESCRIPTION
# feat: v02 device support

## Summary

Adds support for V02 devices (Airjet V02, Hydrojet V02, etc.) that use AWS IoT backend instead of Gizwits.

**Dependency:** ⚠️ Builds on #104 - please merge that PR first.

## Background

As discussed in #103, Bestway migrated V02+ devices to AWS IoT Core, leaving these devices unsupported. An alternative integration exists ([M1R4G376/New_bestway_spa](https://github.com/M1R4G376/New_bestway_spa)) but requires Charles Proxy MITM setup and manual credential extraction.

This PR brings V02 support to the main integration, avoiding community fragmentation.

## Implementation Approach

**Adapter Pattern** - AWS IoT API implements the same interface as `BestwayApi`:
- Existing coordinator: 0 lines changed
- Existing entities: only device type filters added
- All new code isolated in `custom_components/bestway/aws_iot/`

Field normalization layer adapts AWS IoT fields (e.g. `water_temperature`) to Gizwits V01 fields (e.g. `Tnow`) so existing entities work unchanged.

## What M1R4G376/New_bestway_spa Provided

Their implementation showed us:
- AWS IoT REST API endpoint (`smarthub-eu.bestwaycorp.com`)
- MD5 authentication signature pattern
- Device shadow GET/POST patterns

## What This PR Adds

**Features not in M1R4G376/New_bestway_spa:**
- AES-256-CBC encrypted commands (v2 API endpoint)
- Real-time WebSocket updates (per-device connections to regional AWS endpoints)
- QR code binding flow (no MITM proxy needed)
- Automatic device discovery via hierarchical API (homes → rooms → devices)
- Multi-device support (one setup finds all devices)
- Regional endpoint selection (EU/US/CN)

**Setup Comparison:**

| M1R4G376/New_bestway_spa | This PR |
|---------|---------|
| Charles Proxy MITM required | No MITM required |
| Manual entry: visitor_id, registration_id, device_id, product_id, device_name | QR code OR visitor_id only |
| One integration per device | One integration discovers all devices |
| REST polling only | WebSocket + polling fallback |

## User Experience

**Setup Flow:**
1. Select backend: V01 (Gizwits) or V02 (AWS IoT)
2. For V02: Select region (EU/US/CN)
3. Scan QR code from app settings OR enter existing visitor_id
4. All devices automatically discovered

**Tested with Airjet V02 (T53NN8):**
- All controls working: power, temperature, heater, filter, bubbles, lock
- Real-time WebSocket updates (<1s latency)

## Production Improvements

- 10s timeout on all API calls (prevents hangs)
- Device discovery caching (reduces API calls from ~1000/day to ~10/day)
- `ConfigEntryAuthFailed` for proper HA reauth flow
- Per-device WebSocket connections to regional AWS endpoints

## Testing

- Manual testing with Airjet V02 (T53NN8) device
- Automated tests added for AWS IoT module (encryption, API client, WebSocket)

## Compatibility

- V01 configurations continue to function
- No migration required
- V01 and V02 can coexist
- Fallback defaults for existing configs

## Closes

#103, #88

## References

#84, #95, #104

---

This PR unifies V01 and V02 support under the main ha-bestway integration.

## Examples 

### V01

<img width="1075" height="936" alt="image" src="https://github.com/user-attachments/assets/8b312a80-c924-4226-bbd1-f21795ed40b4" />

### V02

<img width="1075" height="849" alt="image" src="https://github.com/user-attachments/assets/b256fc6f-ff5a-42e5-81f0-17cf35b9f203" />

