### PR TITLE
Fix Hydrojet V02 bubbles handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 .coverage
 .idea
 node_modules
+tests/LOGS/

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -126,10 +126,14 @@ class AwsIotApi:
         # V02 wave_state actual values: 0=OFF, 40=MEDIUM, 100=HIGH
         # Map to V01 Airjet format (0/50/100) for AIRJET_V01_BUBBLES_MAP compatibility
         # Note: Hydrojet uses 40 for MEDIUM, so no mapping needed there
+        _LOGGER.debug("🔵 normalize_aws_state: INPUT wave_state=%s", wave_state)
         if wave_state == 40:
             wave_normalized = 50  # Map V02 MEDIUM (40) → V01 Airjet MEDIUM (50)
         else:
             wave_normalized = wave_state  # 0 and 100 are same in both
+        _LOGGER.debug(
+            "🔵 normalize_aws_state: OUTPUT wave_normalized=%s", wave_normalized
+        )
 
         # Build normalized dict, only including fields with actual values
         # This prevents None values from overwriting existing data during merges
@@ -848,6 +852,8 @@ class AwsIotApi:
         Physical button cycles: OFF → HIGH → MEDIUM → OFF
         Try sending absolute values first (simplest approach).
         """
+        _LOGGER.debug("🔵 airjet_v01_spa_set_bubbles: input level=%s", level)
+
         # Map BubblesLevel enum to V02 wave_state values
         value_map = {
             BubblesLevel.OFF: 0,
@@ -856,9 +862,45 @@ class AwsIotApi:
         }
 
         target_value = value_map.get(level)
-        if target_value is not None:
-            await self.set_device_state(device_id, {"wave_state": target_value})
-            _LOGGER.debug("Set bubbles to %s (wave_state=%d)", level.name, target_value)
+        _LOGGER.debug("🔵 airjet_v01_spa_set_bubbles: target_value=%s", target_value)
+
+        if target_value is None:
+            return
+
+        # Some V02 Hydrojet devices ignore a direct MEDIUM (40) command when currently OFF.
+        # Physical button cycles: OFF -> HIGH -> MEDIUM -> OFF. To reliably reach MEDIUM
+        # from OFF, send a HIGH (100) toggle first, wait briefly, then send MEDIUM (40).
+        try:
+            cached = self._state_cache.get(device_id)
+            current_wave = None
+            if cached and isinstance(cached.attrs, dict):
+                current_wave = cached.attrs.get("wave")
+        except Exception:
+            current_wave = None
+
+        # If requesting MEDIUM but currently OFF, perform a toggle sequence
+        if target_value == 40 and (current_wave is None or int(current_wave) == 0):
+            _LOGGER.debug(
+                "🔵 airjet_v01_spa_set_bubbles: current_wave=%s, sending toggle sequence HIGH->MEDIUM",
+                current_wave,
+            )
+            # Send HIGH first
+            await self.set_device_state(device_id, {"wave_state": 100})
+            # Give device a short moment to apply
+            try:
+                await asyncio.sleep(1)
+            except Exception:
+                pass
+            # Now send MEDIUM
+            await self.set_device_state(device_id, {"wave_state": 40})
+            _LOGGER.debug(
+                "🔵 Set bubbles to %s (wave_state=%d after toggle)", level.name, 40
+            )
+            return
+
+        # Default: send the requested absolute value
+        await self.set_device_state(device_id, {"wave_state": target_value})
+        _LOGGER.debug("🔵 Set bubbles to %s (wave_state=%d)", level.name, target_value)
 
     async def hydrojet_spa_set_bubbles(
         self, device_id: str, level: BubblesLevel
@@ -867,6 +909,10 @@ class AwsIotApi:
 
         V02 uses same toggle approach as Airjet V02.
         """
+        _LOGGER.debug(
+            "🔵 hydrojet_spa_set_bubbles: delegating to airjet_v01_spa_set_bubbles with level=%s",
+            level,
+        )
         # V02 uses toggle approach (same as Airjet V02)
         await self.airjet_v01_spa_set_bubbles(device_id, level)
 

--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -152,7 +152,8 @@ class BubblesMapping:
 
 BV = BubblesValues
 AIRJET_V01_BUBBLES_MAP = BubblesMapping(BV(0), BV(50, [40, 41, 50, 51]), BV(100))
-HYDROJET_BUBBLES_MAP = BubblesMapping(BV(0), BV(40), BV(100))
+# Hydrojet devices sometimes report MEDIUM as 40, 41 or (after normalization) 50 — accept all
+HYDROJET_BUBBLES_MAP = BubblesMapping(BV(0), BV(40, [40, 41, 50]), BV(100))
 
 
 @dataclass

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from logging import getLogger
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +22,8 @@ from .bestway.model import (
 )
 from .const import DOMAIN, Icon
 from .entity import BestwayEntity
+
+_LOGGER = getLogger(__name__)
 
 _BUBBLES_OPTIONS = {
     BubblesLevel.OFF: "OFF",
@@ -121,19 +124,38 @@ class ThreeWaySpaBubblesSelect(BestwayEntity, SelectEntity):
     def current_option(self) -> str | None:
         """Return the selected entity option."""
         if device := self.coordinator.data.devices.get(self.device_id):
-            bubbles_level = self.entity_description.get_fn(device.attrs["wave"])
-            return _BUBBLES_OPTIONS.get(bubbles_level)
+            wave_value = device.attrs.get("wave")
+            _LOGGER.debug("🔵 current_option: device.attrs['wave']=%s", wave_value)
+
+            # Ensure we pass an int to the mapping function (mypy-friendly).
+            try:
+                wave_int: int = int(wave_value) if wave_value is not None else 0
+            except Exception:
+                wave_int = 0
+
+            bubbles_level = self.entity_description.get_fn(wave_int)
+            _LOGGER.debug("🔵 current_option: mapped to BubblesLevel=%s", bubbles_level)
+
+            option = _BUBBLES_OPTIONS.get(bubbles_level)
+            _LOGGER.debug("🔵 current_option: final option=%s", option)
+            return option
         return None
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
+        _LOGGER.debug("🔵 async_select_option: user selected option=%s", option)
+
         bubbles_level = BubblesLevel.OFF
         if option == _BUBBLES_OPTIONS[BubblesLevel.MEDIUM]:
             bubbles_level = BubblesLevel.MEDIUM
         elif option == _BUBBLES_OPTIONS[BubblesLevel.MAX]:
             bubbles_level = BubblesLevel.MAX
 
+        _LOGGER.debug(
+            "🔵 async_select_option: mapped to BubblesLevel=%s", bubbles_level
+        )
         await self.entity_description.set_fn(
             self.coordinator.api, self.device_id, bubbles_level
         )
+        _LOGGER.debug("🔵 async_select_option: API call complete, requesting refresh")
         await self.coordinator.async_request_refresh()

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -230,10 +230,23 @@ def test_normalize_state_partial_update_preserves_absent_fields():
 
 def test_normalize_state_wave_mapping():
     """Test V02 wave_state value mapping to V01 format."""
+    from custom_components.bestway.bestway.model import (
+        HYDROJET_BUBBLES_MAP,
+        BubblesLevel,
+    )
+
     # V02 MEDIUM (40) maps to V01 Airjet MEDIUM (50)
     aws_state = {"wave_state": 40}
     normalized = AwsIotApi.normalize_aws_state(aws_state)
     assert normalized["wave"] == 50
+
+    # Hydrojet may report 41; treat it as MEDIUM as well.
+    aws_state = {"wave_state": 41}
+    normalized = AwsIotApi.normalize_aws_state(aws_state)
+    assert normalized["wave"] == 41
+    assert (
+        HYDROJET_BUBBLES_MAP.from_api_value(normalized["wave"]) == BubblesLevel.MEDIUM
+    )
 
     # 0 and 100 are the same in both versions
     aws_state = {"wave_state": 0}
@@ -329,6 +342,44 @@ async def test_set_device_state_sends_command(aws_api, mock_session):
     # Verify
     assert success is True
     assert mock_session.post.called
+
+
+@pytest.mark.asyncio
+async def test_hydrojet_medium_from_off_uses_toggle_sequence(aws_api):
+    """Test MEDIUM from OFF sends HIGH first, then MEDIUM."""
+    from custom_components.bestway.bestway.model import (
+        BestwayDevice,
+        BestwayDeviceStatus,
+        BubblesLevel,
+    )
+    from unittest.mock import AsyncMock, patch
+
+    aws_api.devices = {
+        "device1": BestwayDevice(
+            protocol_version=2,
+            device_id="device1",
+            product_name="AIRJET",
+            alias="Test Spa",
+            mcu_soft_version="unknown",
+            mcu_hard_version="unknown",
+            wifi_soft_version="unknown",
+            wifi_hard_version="unknown",
+            is_online=True,
+            backend="aws_iot",
+            product_id="T53NN8",
+        )
+    }
+    aws_api._state_cache = {
+        "device1": BestwayDeviceStatus(timestamp=0, attrs={"wave": 0})
+    }
+    aws_api.set_device_state = AsyncMock(return_value=True)
+
+    with patch("custom_components.bestway.aws_iot.api.asyncio.sleep", new=AsyncMock()):
+        await aws_api.hydrojet_spa_set_bubbles("device1", BubblesLevel.MEDIUM)
+
+    assert aws_api.set_device_state.await_count == 2
+    assert aws_api.set_device_state.await_args_list[0].args[1] == {"wave_state": 100}
+    assert aws_api.set_device_state.await_args_list[1].args[1] == {"wave_state": 40}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes Hydrojet V02 bubble handling so MEDIUM is detected reliably and can be selected from OFF.

Changes:
- Treat wave_state=41 as MEDIUM.
- Use MAX -> MEDIUM when selecting MEDIUM from OFF.
- Add tests for the V02 mapping and toggle sequence.