### PR TITLE
Fix V02 (Airjet V02) state sync: filter switch, heater UI, shadow merge, WS deltas

### DIFF
--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -602,12 +602,14 @@ class AwsIotApi:
                 # Extract state (EXACT reference logic!)
                 raw_data = shadow_response.get("data", {})
 
-                # Try reported first, then desired, then raw state (reference logic)
-                if "state" in raw_data:
-                    if "reported" in raw_data["state"]:
-                        device_state = raw_data["state"]["reported"]
-                    elif "desired" in raw_data["state"]:
-                        device_state = raw_data["state"]["desired"]
+                # Merge reported + desired so HA reflects the target state
+                # (matches what the Bestway app shows) instead of lagging on
+                # reported until the device fully acks.
+                if "state" in raw_data and isinstance(raw_data["state"], dict):
+                    reported = raw_data["state"].get("reported") or {}
+                    desired = raw_data["state"].get("desired") or {}
+                    if reported or desired:
+                        device_state = {**reported, **desired}
                     else:
                         device_state = raw_data["state"]
                 else:

--- a/custom_components/bestway/aws_iot/websocket.py
+++ b/custom_components/bestway/aws_iot/websocket.py
@@ -228,32 +228,58 @@ class AwsIotWebSocket:
                 await self._schedule_reconnect()
 
     async def _handle_message(self, data: dict[str, Any]) -> None:
-        """Process shadow delta message.
+        """Process shadow update message.
 
-        Args:
-            data: Parsed WebSocket message containing shadow state
+        Handles the three AWS IoT shadow notification shapes:
+        - documents:  {current: {state: {reported: {...}, desired: {...}}}, ...}
+        - update:     {state: {reported: {...}, desired: {...}}, ...}
+        - delta:      {state: {<field>: <value>, ...}, ...}
         """
-        # Extract shadow state (matches AWS IoT shadow delta format)
-        if "state" in data and "reported" in data.get("state", {}):
-            state = data["state"]["reported"]
+        state: dict[str, Any] | None = None
 
-            _LOGGER.debug(
-                "Shadow update for device %s: %d fields",
-                self._device_id[:12],
-                len(state),
-            )
+        # "documents" notification — full shadow snapshot
+        current = data.get("current")
+        if isinstance(current, dict):
+            current_state = current.get("state")
+            if isinstance(current_state, dict):
+                reported = current_state.get("reported") or {}
+                desired = current_state.get("desired") or {}
+                if reported or desired:
+                    state = {**reported, **desired}
 
-            # Normalize AWS field names to Gizwits V01 equivalents using shared method
-            from .api import AwsIotApi
+        # "update" / "delta" notifications carry "state" at the top level
+        if state is None:
+            raw_state = data.get("state")
+            if isinstance(raw_state, dict):
+                reported = raw_state.get("reported")
+                desired = raw_state.get("desired")
+                if isinstance(reported, dict) or isinstance(desired, dict):
+                    # update-style: merge desired over reported (desired wins)
+                    state = {**(reported or {}), **(desired or {})}
+                else:
+                    # delta-style: state values are the deltas themselves
+                    state = raw_state
 
-            normalized = AwsIotApi.normalize_aws_state(state)
+        if not state:
+            return
 
-            # Call coordinator callback with (device_id, normalized_attrs)
-            if self._update_callback is not None:
-                try:
-                    self._update_callback(self._device_id, normalized)
-                except Exception as err:
-                    _LOGGER.error("Callback error: %s", err)
+        _LOGGER.debug(
+            "Shadow update for device %s: %d fields",
+            self._device_id[:12],
+            len(state),
+        )
+
+        # Normalize AWS field names to Gizwits V01 equivalents using shared method
+        from .api import AwsIotApi
+
+        normalized = AwsIotApi.normalize_aws_state(state)
+
+        # Call coordinator callback with (device_id, normalized_attrs)
+        if self._update_callback is not None:
+            try:
+                self._update_callback(self._device_id, normalized)
+            except Exception as err:
+                _LOGGER.error("Callback error: %s", err)
 
     async def _heartbeat_loop(self) -> None:
         """Send heartbeat every 30 seconds to maintain connection."""

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -191,10 +191,20 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
         """Initialize thermostat."""
         super().__init__(coordinator, config_entry, device_id)
         self._attr_unique_id = f"{device_id}_thermostat"
+        self._optimistic_heat: int | None = None
+        self._optimistic_tset: int | None = None
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state when real data arrives."""
+        self._optimistic_heat = None
+        self._optimistic_tset = None
+        super()._handle_coordinator_update()
 
     @property
     def hvac_mode(self) -> HVACMode | None:
         """Return the current mode (HEAT or OFF)."""
+        if self._optimistic_heat is not None:
+            return HVACMode.HEAT if self._optimistic_heat > 0 else HVACMode.OFF
         if not self.status:
             return None
         return HVACMode.HEAT if self.status.attrs["heat"] > 0 else HVACMode.OFF
@@ -202,10 +212,13 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running action (HEATING or IDLE)."""
-        if not self.status:
-            return None
-        heat_on = self.status.attrs["heat"] > 0
-        target_reached = self.status.attrs["heat"] == 4
+        heat_value: int | None = self._optimistic_heat
+        if heat_value is None:
+            if not self.status:
+                return None
+            heat_value = self.status.attrs["heat"]
+        heat_on = heat_value > 0
+        target_reached = heat_value == 4
         return (
             HVACAction.HEATING if (heat_on and not target_reached) else HVACAction.IDLE
         )
@@ -220,6 +233,8 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
+        if self._optimistic_tset is not None:
+            return float(self._optimistic_tset)
         if not self.status:
             return None
         return int(self.status.attrs["Tset"])
@@ -260,14 +275,15 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
-        if hvac_mode == HVACMode.HEAT:
-            await self.coordinator.api.hydrojet_spa_set_heat(
-                self.device_id, HydrojetHeat.ON
-            )
-        else:
-            await self.coordinator.api.hydrojet_spa_set_heat(
-                self.device_id, HydrojetHeat.OFF
-            )
+        want_heat = hvac_mode == HVACMode.HEAT
+        self._optimistic_heat = int(HydrojetHeat.ON) if want_heat else int(
+            HydrojetHeat.OFF
+        )
+        self.async_write_ha_state()
+        await self.coordinator.api.hydrojet_spa_set_heat(
+            self.device_id,
+            HydrojetHeat.ON if want_heat else HydrojetHeat.OFF,
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -277,11 +293,17 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
             return
 
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
-            should_heat = hvac_mode == HVACMode.HEAT
+            want_heat = hvac_mode == HVACMode.HEAT
+            self._optimistic_heat = int(HydrojetHeat.ON) if want_heat else int(
+                HydrojetHeat.OFF
+            )
             await self.coordinator.api.hydrojet_spa_set_heat(
-                self.device_id, should_heat
+                self.device_id,
+                HydrojetHeat.ON if want_heat else HydrojetHeat.OFF,
             )
 
+        self._optimistic_tset = int(target_temperature)
+        self.async_write_ha_state()
         await self.coordinator.api.hydrojet_spa_set_target_temp(
             self.device_id, target_temperature
         )

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from time import monotonic
 from typing import Any
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
@@ -15,6 +16,8 @@ from . import BestwayUpdateCoordinator
 from .bestway.model import BestwayDeviceType, HydrojetHeat
 from .const import DOMAIN
 from .entity import BestwayEntity
+
+_OPTIMISTIC_TIMEOUT_S = 8.0
 
 _SPA_MIN_TEMP_C = 20
 _SPA_MIN_TEMP_F = 68
@@ -192,28 +195,44 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
         super().__init__(coordinator, config_entry, device_id)
         self._attr_unique_id = f"{device_id}_thermostat"
         self._optimistic_heat: int | None = None
+        self._optimistic_heat_set_at: float = 0.0
         self._optimistic_tset: int | None = None
+        self._optimistic_tset_set_at: float = 0.0
+
+    def _set_optimistic_heat(self, value: int) -> None:
+        self._optimistic_heat = value
+        self._optimistic_heat_set_at = monotonic()
+
+    def _set_optimistic_tset(self, value: int) -> None:
+        self._optimistic_tset = value
+        self._optimistic_tset_set_at = monotonic()
 
     def _handle_coordinator_update(self) -> None:
-        """Clear optimistic state only once real data confirms the value.
+        """Clear optimistic state once real data confirms it, or after a
+        short timeout.
 
-        A refresh that fires before the cloud has acked the command would
-        otherwise expose the stale state and flicker the UI back to the
-        previous mode/temperature for a few hundred ms.
+        Without the confirmation check, a refresh that fires before the
+        cloud has acked the command exposes the stale state. Without the
+        timeout, rapid input (or a dropped/reordered command) leaves the
+        UI stuck on a value the cloud never reaches.
         """
+        now = monotonic()
         if self.status is not None:
             attrs = self.status.attrs
             if self._optimistic_heat is not None:
                 want_on = self._optimistic_heat > 0
                 actual_on = attrs.get("heat", 0) > 0
-                if want_on == actual_on:
+                timed_out = now - self._optimistic_heat_set_at >= _OPTIMISTIC_TIMEOUT_S
+                if want_on == actual_on or timed_out:
                     self._optimistic_heat = None
             if self._optimistic_tset is not None:
+                timed_out = now - self._optimistic_tset_set_at >= _OPTIMISTIC_TIMEOUT_S
                 try:
-                    if int(attrs.get("Tset", -1)) == self._optimistic_tset:
-                        self._optimistic_tset = None
+                    matched = int(attrs.get("Tset", -1)) == self._optimistic_tset
                 except (TypeError, ValueError):
-                    pass
+                    matched = False
+                if matched or timed_out:
+                    self._optimistic_tset = None
         super()._handle_coordinator_update()
 
     @property
@@ -292,7 +311,7 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         want_heat = hvac_mode == HVACMode.HEAT
-        self._optimistic_heat = (
+        self._set_optimistic_heat(
             int(HydrojetHeat.ON) if want_heat else int(HydrojetHeat.OFF)
         )
         self.async_write_ha_state()
@@ -310,7 +329,7 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
 
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
             want_heat = hvac_mode == HVACMode.HEAT
-            self._optimistic_heat = (
+            self._set_optimistic_heat(
                 int(HydrojetHeat.ON) if want_heat else int(HydrojetHeat.OFF)
             )
             await self.coordinator.api.hydrojet_spa_set_heat(
@@ -318,7 +337,7 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
                 HydrojetHeat.ON if want_heat else HydrojetHeat.OFF,
             )
 
-        self._optimistic_tset = int(target_temperature)
+        self._set_optimistic_tset(int(target_temperature))
         self.async_write_ha_state()
         await self.coordinator.api.hydrojet_spa_set_target_temp(
             self.device_id, target_temperature

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -195,9 +195,25 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
         self._optimistic_tset: int | None = None
 
     def _handle_coordinator_update(self) -> None:
-        """Clear optimistic state when real data arrives."""
-        self._optimistic_heat = None
-        self._optimistic_tset = None
+        """Clear optimistic state only once real data confirms the value.
+
+        A refresh that fires before the cloud has acked the command would
+        otherwise expose the stale state and flicker the UI back to the
+        previous mode/temperature for a few hundred ms.
+        """
+        if self.status is not None:
+            attrs = self.status.attrs
+            if self._optimistic_heat is not None:
+                want_on = self._optimistic_heat > 0
+                actual_on = attrs.get("heat", 0) > 0
+                if want_on == actual_on:
+                    self._optimistic_heat = None
+            if self._optimistic_tset is not None:
+                try:
+                    if int(attrs.get("Tset", -1)) == self._optimistic_tset:
+                        self._optimistic_tset = None
+                except (TypeError, ValueError):
+                    pass
         super()._handle_coordinator_update()
 
     @property

--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -292,8 +292,8 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         want_heat = hvac_mode == HVACMode.HEAT
-        self._optimistic_heat = int(HydrojetHeat.ON) if want_heat else int(
-            HydrojetHeat.OFF
+        self._optimistic_heat = (
+            int(HydrojetHeat.ON) if want_heat else int(HydrojetHeat.OFF)
         )
         self.async_write_ha_state()
         await self.coordinator.api.hydrojet_spa_set_heat(
@@ -310,8 +310,8 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
 
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
             want_heat = hvac_mode == HVACMode.HEAT
-            self._optimistic_heat = int(HydrojetHeat.ON) if want_heat else int(
-                HydrojetHeat.OFF
+            self._optimistic_heat = (
+                int(HydrojetHeat.ON) if want_heat else int(HydrojetHeat.OFF)
             )
             await self.coordinator.api.hydrojet_spa_set_heat(
                 self.device_id,

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from time import monotonic
 
 from typing import Any
 
@@ -18,6 +19,12 @@ from .bestway.api import BestwayApi
 from .bestway.model import BestwayDeviceStatus, BestwayDeviceType, HydrojetFilter
 from .const import DOMAIN, Icon
 from .entity import BestwayEntity
+
+# Maximum time an optimistic value is trusted before the entity falls back
+# to whatever the cloud last reported. Long enough to ride out a normal
+# Bestway/AWS round trip, short enough that a stuck UI self-heals quickly
+# when commands fail or get processed out of order.
+_OPTIMISTIC_TIMEOUT_S = 8.0
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -227,6 +234,12 @@ class BestwaySwitch(BestwayEntity, SwitchEntity):
         self.entity_description = description
         self._attr_unique_id = f"{device_id}_{description.key}"
         self._optimistic_state: bool | None = None
+        self._optimistic_set_at: float = 0.0
+
+    def _set_optimistic(self, value: bool) -> None:
+        """Set the optimistic value and stamp it for the timeout check."""
+        self._optimistic_state = value
+        self._optimistic_set_at = monotonic()
 
     @property
     def is_on(self) -> bool | None:
@@ -239,31 +252,37 @@ class BestwaySwitch(BestwayEntity, SwitchEntity):
         return None
 
     def _handle_coordinator_update(self) -> None:
-        """Clear optimistic state only once real data confirms the value.
+        """Clear optimistic state once real data confirms it, or after a
+        short timeout.
 
-        Otherwise a refresh that fires before the cloud has acked the
-        command exposes the stale "old" state for a few hundred ms,
-        producing a visible ON -> OFF -> ON flicker.
+        Without the confirmation check, a refresh that fires before the
+        cloud has acked the command exposes the stale "old" state and the
+        UI flickers ON -> OFF -> ON. Without the timeout, a rapid
+        double-tap (or any command the cloud reorders / drops) can leave
+        the switch stuck on the unconfirmed value indefinitely because
+        the real state never matches.
         """
         if self._optimistic_state is not None and self.status is not None:
             try:
                 actual = self.entity_description.value_fn(self.status)
             except (KeyError, TypeError):
                 actual = None
-            if actual == self._optimistic_state:
+            confirmed = actual == self._optimistic_state
+            timed_out = monotonic() - self._optimistic_set_at >= _OPTIMISTIC_TIMEOUT_S
+            if confirmed or timed_out:
                 self._optimistic_state = None
         super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        self._optimistic_state = True
+        self._set_optimistic(True)
         self.async_write_ha_state()
         await self.entity_description.turn_on_fn(self.coordinator.api, self.device_id)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        self._optimistic_state = False
+        self._set_optimistic(False)
         self.async_write_ha_state()
         await self.entity_description.turn_off_fn(self.coordinator.api, self.device_id)
         await self.coordinator.async_request_refresh()

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -78,7 +78,7 @@ _AIRJET_V01_HYDROJET_SPA_FILTER_SWITCH = BestwaySwitchEntityDescription(
     key="spa_filter_power",
     name="Spa Filter",
     icon=Icon.FILTER,
-    value_fn=lambda s: bool(s.attrs["filter"] == 2),
+    value_fn=lambda s: bool(s.attrs.get("filter")),
     turn_on_fn=lambda api, device_id: api.hydrojet_spa_set_filter(
         device_id, HydrojetFilter.ON
     ),

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -239,8 +239,19 @@ class BestwaySwitch(BestwayEntity, SwitchEntity):
         return None
 
     def _handle_coordinator_update(self) -> None:
-        """Clear optimistic state when real data arrives."""
-        self._optimistic_state = None
+        """Clear optimistic state only once real data confirms the value.
+
+        Otherwise a refresh that fires before the cloud has acked the
+        command exposes the stale "old" state for a few hundred ms,
+        producing a visible ON -> OFF -> ON flicker.
+        """
+        if self._optimistic_state is not None and self.status is not None:
+            try:
+                actual = self.entity_description.value_fn(self.status)
+            except (KeyError, TypeError):
+                actual = None
+            if actual == self._optimistic_state:
+                self._optimistic_state = None
         super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/test_availability_and_controls.py
+++ b/tests/test_availability_and_controls.py
@@ -182,8 +182,8 @@ class TestSwitchOptimistic:
         switch._optimistic_state = True
         assert switch.is_on is True
 
-    def test_switch_optimistic_cleared_on_update(self):
-        """Optimistic state is cleared when coordinator provides real data."""
+    def test_switch_optimistic_cleared_when_real_state_matches(self):
+        """Optimistic state is cleared once real data confirms what we set."""
         from custom_components.bestway.switch import (
             BestwaySwitch,
             BestwaySwitchEntityDescription,
@@ -197,21 +197,52 @@ class TestSwitchOptimistic:
             turn_off_fn=AsyncMock(),
         )
         device = _make_device()
+        # Real state already matches what we optimistically set (True)
         status = _make_status({"power": True})
         coordinator = _make_coordinator(device, status)
         config_entry = MagicMock()
 
         switch = BestwaySwitch(coordinator, config_entry, "test_device", desc)
-        switch._optimistic_state = False  # Optimistic says OFF
+        switch._optimistic_state = True
 
-        assert switch.is_on is False  # Optimistic overrides
-
-        # Simulate coordinator update — patch async_write_ha_state since
-        # there's no real HA instance in unit tests
         with patch.object(switch, "async_write_ha_state"):
             switch._handle_coordinator_update()
-        assert switch._optimistic_state is None  # Cleared
-        # Now reads actual state from coordinator (power=True)
+
+        assert switch._optimistic_state is None  # Cleared on confirmation
+        assert switch.is_on is True  # Reads from coordinator now
+
+    def test_switch_optimistic_kept_when_real_state_lags(self):
+        """Optimistic state survives a refresh that hasn't yet caught the change.
+
+        Without this, the UI flickers ON -> OFF -> ON when async_request_refresh
+        fires before the Bestway cloud has acked the command and the shadow
+        still reports the previous value.
+        """
+        from custom_components.bestway.switch import (
+            BestwaySwitch,
+            BestwaySwitchEntityDescription,
+        )
+
+        desc = BestwaySwitchEntityDescription(
+            key="test_power",
+            name="Test Power",
+            value_fn=lambda s: bool(s.attrs["power"]),
+            turn_on_fn=AsyncMock(),
+            turn_off_fn=AsyncMock(),
+        )
+        device = _make_device()
+        # Shadow still has the old value while the command is in flight
+        status = _make_status({"power": False})
+        coordinator = _make_coordinator(device, status)
+        config_entry = MagicMock()
+
+        switch = BestwaySwitch(coordinator, config_entry, "test_device", desc)
+        switch._optimistic_state = True  # User pressed ON
+
+        with patch.object(switch, "async_write_ha_state"):
+            switch._handle_coordinator_update()
+
+        assert switch._optimistic_state is True  # Kept, no flicker
         assert switch.is_on is True
 
 

--- a/tests/test_availability_and_controls.py
+++ b/tests/test_availability_and_controls.py
@@ -238,12 +238,56 @@ class TestSwitchOptimistic:
 
         switch = BestwaySwitch(coordinator, config_entry, "test_device", desc)
         switch._optimistic_state = True  # User pressed ON
+        # Stamp recent so the timeout safety net doesn't fire
+        from time import monotonic
+
+        switch._optimistic_set_at = monotonic()
 
         with patch.object(switch, "async_write_ha_state"):
             switch._handle_coordinator_update()
 
         assert switch._optimistic_state is True  # Kept, no flicker
         assert switch.is_on is True
+
+    def test_switch_optimistic_cleared_after_timeout(self):
+        """Optimistic state is force-cleared if the cloud never confirms.
+
+        Rapid taps or dropped/reordered commands can leave the cloud in a
+        state that never matches the user's last optimistic value. Without
+        a timeout the switch would stick on the unconfirmed value forever;
+        the timeout self-heals the UI back to reality.
+        """
+        from custom_components.bestway.switch import (
+            BestwaySwitch,
+            BestwaySwitchEntityDescription,
+            _OPTIMISTIC_TIMEOUT_S,
+        )
+
+        desc = BestwaySwitchEntityDescription(
+            key="test_power",
+            name="Test Power",
+            value_fn=lambda s: bool(s.attrs["power"]),
+            turn_on_fn=AsyncMock(),
+            turn_off_fn=AsyncMock(),
+        )
+        device = _make_device()
+        # Cloud says OFF, but user's last optimistic value was ON.
+        status = _make_status({"power": False})
+        coordinator = _make_coordinator(device, status)
+        config_entry = MagicMock()
+
+        switch = BestwaySwitch(coordinator, config_entry, "test_device", desc)
+        switch._optimistic_state = True
+        from time import monotonic
+
+        # Stamp far enough in the past that the timeout has elapsed.
+        switch._optimistic_set_at = monotonic() - _OPTIMISTIC_TIMEOUT_S - 1
+
+        with patch.object(switch, "async_write_ha_state"):
+            switch._handle_coordinator_update()
+
+        assert switch._optimistic_state is None  # Cleared by timeout
+        assert switch.is_on is False  # Falls back to real cloud state
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aws_iot_websocket.py
+++ b/tests/test_aws_iot_websocket.py
@@ -87,6 +87,69 @@ async def test_handle_message_no_callback_error(aws_websocket):
 
 
 @pytest.mark.asyncio
+async def test_handle_message_delta_shape(aws_websocket, mock_callback):
+    """Delta-shape shadow messages (no nested reported/desired) reach the callback.
+
+    AWS IoT also publishes update-delta notifications where the changed
+    fields live directly under "state". Before the fix these were silently
+    dropped.
+    """
+    message = {"state": {"power_state": 1, "filter_state": 1}, "version": 42}
+
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state"
+    ) as mock_normalize:
+        mock_normalize.return_value = {"power": True, "filter": 1}
+        await aws_websocket._handle_message(message)
+
+    mock_normalize.assert_called_once_with({"power_state": 1, "filter_state": 1})
+    mock_callback.assert_called_once()
+    assert mock_callback.call_args[0][1] == {"power": True, "filter": 1}
+
+
+@pytest.mark.asyncio
+async def test_handle_message_documents_shape(aws_websocket, mock_callback):
+    """Documents-shape shadow snapshots (current.state.reported) reach the callback."""
+    message = {
+        "current": {
+            "state": {
+                "reported": {"power_state": 1},
+                "desired": {"heater_state": 1},
+            }
+        }
+    }
+
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state"
+    ) as mock_normalize:
+        mock_normalize.return_value = {"power": True, "heat": 1}
+        await aws_websocket._handle_message(message)
+
+    # desired wins over reported on key conflicts; here they're disjoint
+    mock_normalize.assert_called_once_with({"power_state": 1, "heater_state": 1})
+    mock_callback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_desired_overrides_reported(aws_websocket, mock_callback):
+    """When reported and desired disagree, desired wins (matches Bestway app)."""
+    message = {
+        "state": {
+            "reported": {"filter_state": 0},
+            "desired": {"filter_state": 1},
+        }
+    }
+
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.normalize_aws_state"
+    ) as mock_normalize:
+        mock_normalize.return_value = {"filter": 1}
+        await aws_websocket._handle_message(message)
+
+    mock_normalize.assert_called_once_with({"filter_state": 1})
+
+
+@pytest.mark.asyncio
 async def test_http_400_triggers_token_refresh(aws_websocket):
     """Test HTTP 400 error triggers token refresh and immediate retry."""
     token_refresh = AsyncMock(return_value="new_token_789")


### PR DESCRIPTION
## Summary

V02 devices (Airjet V02 / Ultrafit Airjet V02 / Hydrojet V02) were showing wrong state in HA while the physical spa and the Bestway app worked correctly. Field-tested against a live Airjet V02.

### Bugs fixed

**1. Spa Filter switch always read OFF on V02** — `switch.py:81`
`value_fn=lambda s: bool(s.attrs["filter"] == 2)` only matches the V01 ON value (2). V02 reports `filter_state=0/1` (see comment in `hydrojet_spa_set_filter` at `aws_iot/api.py:805-815`). On V02 the integration permanently disagreed with the device: turn filter on → switch still shows off; turn filter off → sometimes still shows on (intermediate value `2`). Changed to a truthy check so both V01 (0/2) and V02 (0/1) work.

**2. Climate entity had no optimistic state** — `climate.py` (AirjetV01HydrojetSpaThermostat)
Pressing "Heat" in HA sent the right command (verified — heater starts, Bestway app shows heating), but the HA UI sat on the cached `heat=0` until the shadow refresh completed. Added optimistic `hvac_mode` + `target_temperature` mirroring the pattern the switch entities already use.

**3. `async_set_temperature` silently turned heat off** — `climate.py`
```python
if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
    should_heat = hvac_mode == HVACMode.HEAT  # bool
    await self.coordinator.api.hydrojet_spa_set_heat(self.device_id, should_heat)
```
`hydrojet_spa_set_heat` expects `HydrojetHeat` (3 == ON); `True == 3` is False, so the helper always sent `heater_state=0`. Now passes the enum.

**4. Shadow polling preferred `reported` over `desired`** — `aws_iot/api.py` `fetch_data`
Right after sending a command, `desired.<field>` is the new value but `reported.<field>` still echoes the old state until the device acks (often a poll cycle behind). The Bestway app shows `desired` immediately. Now merges `desired` over `reported` so HA tracks the intended state.

**5. WebSocket dropped delta and documents-shape shadow messages** — `aws_iot/websocket.py` `_handle_message`
Only `{state: {reported: {...}}}` was handled. AWS IoT also emits:
- delta:     `{state: {<field>: <value>}, version, ...}`
- documents: `{current: {state: {reported: {...}, desired: {...}}}, ...}`

Both were silently dropped, so the "real-time" channel was deaf to most updates and HA had to wait for the next 30s/5min poll. Now all three shapes are handled.

**6. Optimistic state cleared too eagerly caused a UI flicker** — `switch.py` + `climate.py` `_handle_coordinator_update`
After fix #2/#4, pressing a switch produced a visible **ON → OFF → ON** flicker (and the same for the thermostat). The optimistic value was cleared on the next `_handle_coordinator_update`, but the refresh that fires immediately after a command often arrives before the Bestway cloud has processed it — so the cleared optimistic value was replaced by the old reported state for a few hundred ms until the real ack came in. Now the optimistic value is only cleared once the incoming real state actually matches what the user asked for; until then it keeps showing the optimistic value so the UI stays steady through the round trip.

**7. Optimistic state stuck on rapid input / reordered commands** — `switch.py` + `climate.py`
Fix #6 introduced the inverse risk: if you tap a switch quickly enough that the cloud receives commands out of order (or drops one), the final cloud state can disagree with your last optimistic value indefinitely, and the UI would stay frozen on the wrong value. Now the optimistic value is also force-cleared after an 8-second timeout if confirmation never arrives — long enough to absorb normal AWS shadow latency, short enough to self-heal quickly when commands don't take effect.

## Test plan

- [x] Live Airjet V02: filter ON → switch flips immediately and stays on (no flicker)
- [x] Live Airjet V02: filter OFF → switch flips off and stays off (no flicker)
- [x] Live Airjet V02: thermostat → Heat → mode + Heating action render instantly, stay consistent with spa LCD + Bestway app
- [x] Live Airjet V02: state remains consistent across app + spa + HA after each transition
- [x] Live Airjet V02: rapid ON/OFF taps reconcile to the real cloud state within the 8s timeout (no stuck switches)
- [ ] Regression check on V01 hardware (filter `2` is still truthy, so the value_fn change is backwards-compatible by construction; no behavior change expected, but I don't have a V01 to verify)
- [ ] CI test suite (runs on this PR)

Closes the spa-side symptoms reported by V02 users in the wake of v1.8.x.
