### PR TITLE
Airjet V02 bubbles: user-selectable on/off vs 3-way

### DIFF
--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -8,8 +8,13 @@ from logging import getLogger
 from typing import Any
 
 from aiohttp import ClientConnectionError
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
@@ -23,9 +28,13 @@ from .bestway.api import (
 from .const import (
     BACKEND_AWS_IOT,
     BACKEND_GIZWITS,
+    BUBBLES_MODE_3WAY,
+    BUBBLES_MODE_DEFAULT,
+    BUBBLES_MODE_ONOFF,
     CONF_API_ROOT,
     CONF_API_ROOT_EU,
     CONF_API_ROOT_US,
+    CONF_BUBBLES_MODE,
     CONF_PASSWORD,
     CONF_UID,
     CONF_USER_TOKEN,
@@ -82,6 +91,12 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize config flow."""
         super().__init__()
         self._backend: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow handler."""
+        return BestwayOptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -345,4 +360,47 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+
+class BestwayOptionsFlowHandler(OptionsFlow):
+    """Handle options for an existing Bestway config entry."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialise options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the integration options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current_mode = self.config_entry.options.get(
+            CONF_BUBBLES_MODE, BUBBLES_MODE_DEFAULT
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_BUBBLES_MODE, default=current_mode
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(
+                                    value=BUBBLES_MODE_3WAY,
+                                    label="3 levels (Off / Medium / Max)",
+                                ),
+                                selector.SelectOptionDict(
+                                    value=BUBBLES_MODE_ONOFF,
+                                    label="On / Off only",
+                                ),
+                            ]
+                        )
+                    ),
+                }
+            ),
         )

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -95,8 +95,12 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        """Return the options flow handler."""
-        return BestwayOptionsFlowHandler(config_entry)
+        """Return the options flow handler.
+
+        The framework injects ``config_entry`` onto the returned flow as
+        a property, so we don't pass it through the constructor.
+        """
+        return BestwayOptionsFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -364,11 +368,12 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class BestwayOptionsFlowHandler(OptionsFlow):
-    """Handle options for an existing Bestway config entry."""
+    """Handle options for an existing Bestway config entry.
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialise options flow."""
-        self.config_entry = config_entry
+    In modern Home Assistant ``self.config_entry`` is a read-only
+    property injected by the framework, so we don't override
+    ``__init__`` or assign to it here.
+    """
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/bestway/const.py
+++ b/custom_components/bestway/const.py
@@ -17,6 +17,14 @@ GIZWITS_APP_ID = "98754e684ec045528b073876c34c7348"
 BACKEND_GIZWITS = "gizwits"
 BACKEND_AWS_IOT = "aws_iot"
 
+# Bubble UI mode (Airjet V02). Some V02 hardware (e.g. T53NN8 batches)
+# only has on/off bubbles physically, while others support 3 levels.
+# The product_id doesn't distinguish them, so the user picks.
+CONF_BUBBLES_MODE = "bubbles_mode"
+BUBBLES_MODE_3WAY = "three_way"
+BUBBLES_MODE_ONOFF = "on_off"
+BUBBLES_MODE_DEFAULT = BUBBLES_MODE_3WAY
+
 
 class Icon(str, Enum):
     """Icon styles."""

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -68,11 +68,10 @@ async def async_setup_entry(
     entities: list[BestwayEntity] = []
 
     for device_id, device in coordinator.api.devices.items():
-        if device.device_type in [
-            BestwayDeviceType.AIRJET_V01_SPA,
-            BestwayDeviceType.AIRJET_V02,
-            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
-        ]:
+        # V01 Airjet has 3 physical levels (OFF/MEDIUM/MAX) and uses the select.
+        # V02 Airjet (e.g. T53NN8) only has on/off physically even though the
+        # shadow accepts wave_state=40 — handled by a switch in switch.py.
+        if device.device_type == BestwayDeviceType.AIRJET_V01_SPA:
             entities.append(
                 ThreeWaySpaBubblesSelect(
                     coordinator,

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -19,7 +19,13 @@ from .bestway.model import (
     BestwayDeviceType,
     BubblesLevel,
 )
-from .const import DOMAIN, Icon
+from .const import (
+    BUBBLES_MODE_3WAY,
+    BUBBLES_MODE_DEFAULT,
+    CONF_BUBBLES_MODE,
+    DOMAIN,
+    Icon,
+)
 from .entity import BestwayEntity
 
 _BUBBLES_OPTIONS = {
@@ -67,11 +73,22 @@ async def async_setup_entry(
     coordinator: BestwayUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
     entities: list[BestwayEntity] = []
 
+    bubbles_mode = config_entry.options.get(CONF_BUBBLES_MODE, BUBBLES_MODE_DEFAULT)
+
     for device_id, device in coordinator.api.devices.items():
-        # V01 Airjet has 3 physical levels (OFF/MEDIUM/MAX) and uses the select.
-        # V02 Airjet (e.g. T53NN8) only has on/off physically even though the
-        # shadow accepts wave_state=40 — handled by a switch in switch.py.
-        if device.device_type == BestwayDeviceType.AIRJET_V01_SPA:
+        # V01 Airjet has 3 physical levels (OFF/MEDIUM/MAX) and always uses the select.
+        # V02 Airjet hardware varies: some have 3 levels, some only on/off. The
+        # product_id doesn't tell them apart, so we honour the user's choice
+        # from the options flow. Default (3-way) is the safe pre-existing
+        # behaviour; on/off mode shows a switch in switch.py instead.
+        if device.device_type == BestwayDeviceType.AIRJET_V01_SPA or (
+            device.device_type
+            in (
+                BestwayDeviceType.AIRJET_V02,
+                BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+            )
+            and bubbles_mode == BUBBLES_MODE_3WAY
+        ):
             entities.append(
                 ThreeWaySpaBubblesSelect(
                     coordinator,

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -56,6 +56,18 @@ _AIRJET_SPA_BUBBLES_SWITCH = BestwaySwitchEntityDescription(
     turn_off_fn=lambda api, device_id: api.airjet_spa_set_bubbles(device_id, False),
 )
 
+# V02 Airjet (e.g. T53NN8) only supports on/off bubbles physically, even
+# though the device shadow accepts/echoes the 0/40/100 wave_state values.
+# Use a simple switch instead of the 3-way select.
+_AIRJET_V02_BUBBLES_SWITCH = BestwaySwitchEntityDescription(
+    key="spa_wave_power",
+    name="Spa Bubbles",
+    icon=Icon.BUBBLES,
+    value_fn=lambda s: bool(s.attrs.get("wave")),
+    turn_on_fn=lambda api, device_id: api.airjet_spa_set_bubbles(device_id, True),
+    turn_off_fn=lambda api, device_id: api.airjet_spa_set_bubbles(device_id, False),
+)
+
 _AIRJET_SPA_LOCK_SWITCH = BestwaySwitchEntityDescription(
     key="spa_locked",
     name="Spa Locked",
@@ -165,6 +177,21 @@ async def async_setup_entry(
                         _AIRJET_V01_HYDROJET_SPA_FILTER_SWITCH,
                     ),
                 ]
+            )
+
+        # V02 Airjet bubbles are on/off only (no MEDIUM level despite the
+        # shadow accepting wave_state=40). Expose as a switch.
+        if device.device_type in [
+            BestwayDeviceType.AIRJET_V02,
+            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+        ]:
+            entities.append(
+                BestwaySwitch(
+                    coordinator,
+                    config_entry,
+                    device_id,
+                    _AIRJET_V02_BUBBLES_SWITCH,
+                )
             )
 
         # V01 and V02 Hydrojet devices (normalization provides consistent field names)

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -16,7 +16,13 @@ from . import BestwayUpdateCoordinator
 from .aws_iot.api import AwsIotApi
 from .bestway.api import BestwayApi
 from .bestway.model import BestwayDeviceStatus, BestwayDeviceType, HydrojetFilter
-from .const import DOMAIN, Icon
+from .const import (
+    BUBBLES_MODE_DEFAULT,
+    BUBBLES_MODE_ONOFF,
+    CONF_BUBBLES_MODE,
+    DOMAIN,
+    Icon,
+)
 from .entity import BestwayEntity
 
 
@@ -179,12 +185,19 @@ async def async_setup_entry(
                 ]
             )
 
-        # V02 Airjet bubbles are on/off only (no MEDIUM level despite the
-        # shadow accepting wave_state=40). Expose as a switch.
-        if device.device_type in [
-            BestwayDeviceType.AIRJET_V02,
-            BestwayDeviceType.ULTRAFIT_AIRJET_V02,
-        ]:
+        # V02 Airjet bubbles: some models physically only have on/off,
+        # others have 3 levels (the product_id doesn't distinguish them).
+        # When the user has chosen the "on/off" mode in options, expose
+        # a switch here; otherwise the 3-way select in select.py handles it.
+        bubbles_mode = config_entry.options.get(CONF_BUBBLES_MODE, BUBBLES_MODE_DEFAULT)
+        if (
+            device.device_type
+            in [
+                BestwayDeviceType.AIRJET_V02,
+                BestwayDeviceType.ULTRAFIT_AIRJET_V02,
+            ]
+            and bubbles_mode == BUBBLES_MODE_ONOFF
+        ):
             entities.append(
                 BestwaySwitch(
                     coordinator,

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -42,5 +42,19 @@
       "qr_code_required": "Either provide an existing visitor_id OR scan a QR code. One option is required.",
       "unknown": "Unknown error"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Bestway options",
+        "description": "Adjust how the integration represents your spa in Home Assistant.",
+        "data": {
+          "bubbles_mode": "Airjet V02 bubble control"
+        },
+        "data_description": {
+          "bubbles_mode": "Some Airjet V02 hot tubs only have on/off bubbles physically, even though the cloud accepts a 3-level value. Pick the option that matches your hardware. Changes apply after the integration reloads."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Airjet V02 bubble hardware varies between batches: some models have three physical levels (Off / Medium / Max), others only on/off. The product_id (e.g. `T53NN8`) doesn't distinguish them — two users on the exact same product_id reported different physical behaviour. The cloud accepts and echoes `wave_state ∈ {0, 40, 100}` either way, so we can't auto-detect.

Let the user pick.

## Change

- New integration-wide option `bubbles_mode` exposed via an options flow (Settings → Devices → Bestway → Configure):
  - **3 levels (Off / Medium / Max)** — default, matches current behaviour.
  - **On / Off only** — replaces the select with a switch.
- `switch.py` registers the V02 on/off bubbles switch only when the option is `on_off`.
- `select.py` registers the 3-way select for V02 Airjet only when the option is `three_way` (the default), and always for V01.
- Changing the option triggers the existing `async_reload_entry` listener so the switch ↔ select swap happens without a restart.
- Hydrojet (V01 / V02 / Pro): unchanged — always uses the 3-way select.

## Upgrade behaviour

- **Existing users on `main`:** no change. Default mode is 3-way, identical to today.
- **Users who switch to On/Off:** the `select.<entity>_bubbles` becomes unavailable and a new `switch.<entity>_bubbles` appears. Delete the old select from the device page if you want it gone.
- **Switching back:** the inverse — switch becomes unavailable, select reappears.

## Test plan

- [x] Live Airjet V02 (`T53NN8`, on/off hardware): toggling the option to On/Off swaps the entity, switch turns bubbles on/off correctly.
- [x] Default mode (3-way) leaves existing entities unchanged.
- [ ] Live test on a 3-level V02 (reported by other user — same product_id) — would appreciate a quick confirmation in the comments.
- [x] V01 Airjet regression check (V01 path is untouched, so should be safe).
- [ ] CI test suite.

## Why option, not auto-detect

Tried auto-detect first — set `wave_state=40` and check what gets reported back. Both hardware variants echo `40`, because the cloud just stores the value the integration sent. The physical motor behaviour is the only differentiator, and the integration can't observe that.

Independent of #116 (no shared changes). Either order is fine.
