### PR TITLE
Fix Hydrojet V02 bubbles MEDIUM rendering as OFF

### DIFF
--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -123,13 +123,17 @@ class AwsIotApi:
         temperature_unit = device_state.get("temperature_unit", 1)
         wave_state = device_state.get("wave_state", 0)
 
-        # V02 wave_state actual values: 0=OFF, 40=MEDIUM, 100=HIGH
-        # Map to V01 Airjet format (0/50/100) for AIRJET_V01_BUBBLES_MAP compatibility
-        # Note: Hydrojet uses 40 for MEDIUM, so no mapping needed there
-        if wave_state == 40:
-            wave_normalized = 50  # Map V02 MEDIUM (40) → V01 Airjet MEDIUM (50)
-        else:
-            wave_normalized = wave_state  # 0 and 100 are same in both
+        # V02 wave_state actual values: 0=OFF, 40=MEDIUM, 100=HIGH.
+        # Pass the raw device value straight through. Both bubble maps already
+        # recognise 40 as MEDIUM: HYDROJET_BUBBLES_MAP natively, and
+        # AIRJET_V01_BUBBLES_MAP since PR #101 widened its MEDIUM read_values to
+        # [40, 41, 50, 51]. The previous code rewrote 40 -> 50, which Hydrojet's
+        # map rejected ("Unexpected API value 50 - assuming OFF"), so Hydrojet
+        # MEDIUM always fell back to displaying OFF (BUG-SPA-6).
+        wave_normalized = wave_state
+        _LOGGER.debug(
+            "normalize wave_state: raw=%s -> wave=%s", wave_state, wave_normalized
+        )
 
         # Build normalized dict, only including fields with actual values
         # This prevents None values from overwriting existing data during merges

--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -152,7 +152,12 @@ class BubblesMapping:
 
 BV = BubblesValues
 AIRJET_V01_BUBBLES_MAP = BubblesMapping(BV(0), BV(50, [40, 41, 50, 51]), BV(100))
-HYDROJET_BUBBLES_MAP = BubblesMapping(BV(0), BV(40), BV(100))
+# Hydrojet V02 (e.g. product T8HDVS) reports MEDIUM as 42, not 40 — the same
+# kind of per-firmware drift that PR #101 handled for Airjet (40/41/50/51).
+# Accept a 40-43 band for MEDIUM so the running state is recognised instead of
+# logging "Unexpected API value 42 - assuming OFF" and showing the tile as OFF.
+# Write value stays 40 (the device accepts 40 as the "go to medium" command).
+HYDROJET_BUBBLES_MAP = BubblesMapping(BV(0), BV(40, [40, 41, 42, 43]), BV(100))
 
 
 @dataclass

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -229,13 +229,18 @@ def test_normalize_state_partial_update_preserves_absent_fields():
 
 
 def test_normalize_state_wave_mapping():
-    """Test V02 wave_state value mapping to V01 format."""
-    # V02 MEDIUM (40) maps to V01 Airjet MEDIUM (50)
+    """Test V02 wave_state is passed through unchanged.
+
+    The normaliser used to rewrite 40 -> 50, which the Hydrojet bubble map
+    rejected, so Hydrojet MEDIUM always rendered as OFF (BUG-SPA-6). Both
+    bubble maps now recognise 40 as MEDIUM directly, so the raw device value
+    is passed straight through.
+    """
+    # MEDIUM (40) is no longer remapped to 50
     aws_state = {"wave_state": 40}
     normalized = AwsIotApi.normalize_aws_state(aws_state)
-    assert normalized["wave"] == 50
+    assert normalized["wave"] == 40
 
-    # 0 and 100 are the same in both versions
     aws_state = {"wave_state": 0}
     normalized = AwsIotApi.normalize_aws_state(aws_state)
     assert normalized["wave"] == 0

--- a/tests/test_aws_iot_model.py
+++ b/tests/test_aws_iot_model.py
@@ -1,6 +1,25 @@
 """Tests for AWS IoT model extensions."""
 
-from custom_components.bestway.bestway.model import BestwayDevice, BestwayDeviceType
+from custom_components.bestway.bestway.model import (
+    HYDROJET_BUBBLES_MAP,
+    BestwayDevice,
+    BestwayDeviceType,
+    BubblesLevel,
+)
+
+
+def test_hydrojet_bubbles_map_reads_medium_band():
+    """Hydrojet V02 firmware reports MEDIUM as 42, not 40 (BUG-SPA-6).
+
+    Accept the 40-43 band as MEDIUM so the running state is recognised
+    instead of falling back to OFF, while the command value stays 40.
+    """
+    assert HYDROJET_BUBBLES_MAP.from_api_value(0) == BubblesLevel.OFF
+    for medium in (40, 41, 42, 43):
+        assert HYDROJET_BUBBLES_MAP.from_api_value(medium) == BubblesLevel.MEDIUM
+    assert HYDROJET_BUBBLES_MAP.from_api_value(100) == BubblesLevel.MAX
+    # The command sent to the device for MEDIUM is unchanged.
+    assert HYDROJET_BUBBLES_MAP.to_api_value(BubblesLevel.MEDIUM) == 40
 
 
 def test_from_aws_product_series_mappings():


### PR DESCRIPTION
## Summary

Fixes the Hydrojet V02 bubbles state showing OFF while the blower is actually running at MEDIUM. This is the Hydrojet counterpart to #101 (which widened the Airjet V01 map).

## Root cause

Two compounding issues on the AWS IoT backend:

1. `AwsIotApi.normalize_aws_state` rewrote `wave_state 40 -> 50` for every device. The Hydrojet bubble map only accepted `40` for MEDIUM, so the remapped `50` was rejected (`Unexpected API value 50 - assuming OFF`) and the tile fell back to OFF whenever bubbles ran at MEDIUM. The remap only ever mattered for Airjet V01, and #101 already widened that map to accept `40/41`, so the rewrite was redundant for Airjet and actively harmful for Hydrojet.
2. Live debug logs from a Hydrojet V02 (product `T8HDVS`) showed the unit reports MEDIUM as `wave_state=42`, not `40`. Even after dropping the remap, `HYDROJET_BUBBLES_MAP` still only listed `40`, so `42` logged `Unexpected API value 42 - assuming OFF`.

## Fix

- `aws_iot/api.py`: pass the raw `wave_state` through unchanged (drop the `40 -> 50` remap) and add a debug log of the raw value.
- `bestway/model.py`: widen `HYDROJET_BUBBLES_MAP` MEDIUM read values to the `40-43` band (`[40, 41, 42, 43]`), mirroring #101's Airjet `[40, 41, 50, 51]`. The command value sent for MEDIUM stays `40`.

## Verification

- Full test suite green (84 passed) on top of current `main`, including the Airjet V02 tests from #116/#117.
- Updated `test_normalize_state_wave_mapping` to assert the pass-through behaviour, and added `test_hydrojet_bubbles_map_reads_medium_band` covering `40-43 -> MEDIUM` and the unchanged `MEDIUM -> 40` command value.
- Verified live on the affected hardware: with the patch deployed the tile correctly shows MEDIUM while the device runs at `wave_state=42`.

## Known limitation (not fixed here)

Commanding MEDIUM from OFF makes this unit step to HIGH first (an `OFF -> HIGH -> MEDIUM` firmware cycle): a MEDIUM command from OFF lands on `wave_state=100` (HIGH), and only a subsequent MEDIUM from HIGH steps the device down to `42` (MEDIUM). This is a firmware step-cycle, not a missing power command, and it is out of scope for this PR. Manual workaround: turn bubbles on first, then select MEDIUM. This display fix makes the running state legible regardless.
