### PR TITLE
Make V02 authentication failures recoverable

### DIFF
--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -211,9 +211,6 @@ async def _async_setup_aws_iot(
     def token_updated(new_token: str) -> None:
         nonlocal token
         token = new_token
-        hass.config_entries.async_update_entry(
-            entry, data={**entry.data, "token": new_token}
-        )
         for websocket in coordinator.websockets:
             websocket.update_token(new_token)
 

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from logging import getLogger
 
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -158,7 +158,11 @@ async def _async_setup_aws_iot(
     hass: HomeAssistant, entry: ConfigEntry, session: ClientSession
 ) -> bool:
     """Set up AWS IoT V02 backend."""
-    from .aws_iot.api import AwsIotApi, AwsIotAuthException
+    from .aws_iot.api import (
+        AwsIotApi,
+        AwsIotAuthException,
+        AwsIotConnectionError,
+    )
     from .aws_iot.websocket import AwsIotWebSocket
 
     visitor_id = entry.data["visitor_id"]
@@ -193,7 +197,10 @@ async def _async_setup_aws_iot(
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, "token": token}
         )
-        api._token = token
+        api.update_token(token)
+    except (AwsIotConnectionError, TimeoutError, ClientError) as ex:
+        _LOGGER.warning("AWS IoT authentication service unavailable: %s", ex)
+        raise ConfigEntryNotReady from ex
     except AwsIotAuthException as ex:
         _LOGGER.error("AWS IoT authentication failed: %s", ex)
         raise ConfigEntryAuthFailed from ex
@@ -212,10 +219,12 @@ async def _async_setup_aws_iot(
                     new_token = await AwsIotApi.authenticate(
                         session, visitor_id, location, api_base
                     )
-                    api._token = new_token
+                    api.update_token(new_token)
                     hass.config_entries.async_update_entry(
                         entry, data={**entry.data, "token": new_token}
                     )
+                    for websocket in coordinator.websockets:
+                        websocket.update_token(new_token)
                     return new_token
 
                 ws = AwsIotWebSocket(

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -207,10 +207,21 @@ async def _async_setup_aws_iot(
 
     # Initialize coordinator
     coordinator = BestwayUpdateCoordinator(hass, entry, api)
+
+    def token_updated(new_token: str) -> None:
+        nonlocal token
+        token = new_token
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "token": new_token}
+        )
+        for websocket in coordinator.websockets:
+            websocket.update_token(new_token)
+
+    api.set_token_update_callback(token_updated)
     await coordinator.async_config_entry_first_refresh()
 
     # Initialize per-device WebSockets
-    websockets = []
+    websockets = coordinator.websockets
     if api.devices:
         for device_id, device in api.devices.items():
             try:
@@ -220,11 +231,6 @@ async def _async_setup_aws_iot(
                         session, visitor_id, location, api_base
                     )
                     api.update_token(new_token)
-                    hass.config_entries.async_update_entry(
-                        entry, data={**entry.data, "token": new_token}
-                    )
-                    for websocket in coordinator.websockets:
-                        websocket.update_token(new_token)
                     return new_token
 
                 ws = AwsIotWebSocket(
@@ -257,8 +263,6 @@ async def _async_setup_aws_iot(
         _LOGGER.warning("No devices found, WebSocket not initialized")
 
     # Store WebSockets list on coordinator
-    coordinator.websockets = websockets
-
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -15,6 +15,7 @@ import asyncio
 import hashlib
 import logging
 import secrets
+from collections.abc import Callable
 from time import time
 from typing import Any
 
@@ -98,6 +99,7 @@ class AwsIotApi:
 
         # State cache (matches Gizwits interface)
         self._state_cache: dict[str, BestwayDeviceStatus] = {}
+        self._token_update_callback: Callable[[str], None] | None = None
 
     @staticmethod
     def generate_visitor_id() -> str:
@@ -281,12 +283,12 @@ class AwsIotApi:
                 async with session.post(
                     url, headers=headers, json=payload, ssl=False
                 ) as resp:
+                    if resp.status in (401, 403):
+                        raise AwsIotAuthException("Authentication rejected")
+
                     data = await resp.json()
                     _LOGGER.debug("Auth response: %s", data)
                     _LOGGER.debug("Response status: %s", resp.status)
-
-                    if resp.status in (401, 403):
-                        raise AwsIotAuthException("Authentication rejected")
 
                     token = data.get("data", {}).get("token")
                     if not token:
@@ -302,6 +304,12 @@ class AwsIotApi:
     def update_token(self, token: str) -> None:
         """Replace the token used by subsequent API requests."""
         self._token = token
+        if self._token_update_callback is not None:
+            self._token_update_callback(token)
+
+    def set_token_update_callback(self, callback: Callable[[str], None] | None) -> None:
+        """Set a callback for persisting and propagating refreshed tokens."""
+        self._token_update_callback = callback
 
     @staticmethod
     async def bind_qr_code(
@@ -420,15 +428,14 @@ class AwsIotApi:
 
         async with asyncio.timeout(TIMEOUT):
             async with self._session.get(url, headers=headers, ssl=False) as response:
-                data = await response.json()
-
                 # Check for errors
-                if response.status in (400, 401):
+                if response.status in (400, 401, 403):
                     raise AwsIotAuthException("Token expired or invalid")
 
                 if response.status != 200:
                     raise AwsIotException(f"API error: {response.status}")
 
+                data = await response.json()
                 return dict(data)
 
     async def _do_post(self, path: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -454,19 +461,17 @@ class AwsIotApi:
             async with self._session.post(
                 url, headers=headers, json=data, ssl=False
             ) as response:
-                result = await response.json()
-
-                _LOGGER.debug(
-                    "POST %s response (status=%d): %s", path, response.status, result
-                )
-
                 # Check for errors
-                if response.status in (400, 401):
+                if response.status in (400, 401, 403):
                     raise AwsIotAuthException("Token expired or invalid")
 
                 if response.status != 200:
                     raise AwsIotException(f"API error: {response.status}")
 
+                result = await response.json()
+                _LOGGER.debug(
+                    "POST %s response (status=%d): %s", path, response.status, result
+                )
                 return dict(result)
 
     async def refresh_bindings(self) -> None:
@@ -586,23 +591,10 @@ class AwsIotApi:
 
             self.devices[device_id] = device
 
-    async def fetch_data(self) -> Any:  # Returns BestwayApiResults
-        """Fetch latest state for all devices.
-
-        Implements the same interface as Gizwits BestwayApi.fetch_data().
-
-        For each device:
-        1. POST /api/device/thing_shadow/ with device_id + product_id
-        2. Parse shadow.state.reported or shadow.state.desired
-        3. Return raw AWS field names (water_temperature, temperature_setting, etc.)
-        4. Store in state cache
-
-        Returns:
-            BestwayApiResults with devices dict
-        """
-        # Import here to avoid circular dependency
-        from ..bestway.api import BestwayApiResults
-
+    async def _poll_all_devices(self) -> tuple[int, bool]:
+        """Poll every device once and return success and auth-failure status."""
+        refreshed = 0
+        auth_failed = False
         for device_id in self.devices:
             try:
                 # Get device metadata
@@ -656,6 +648,7 @@ class AwsIotApi:
                 self._state_cache[device_id] = BestwayDeviceStatus(
                     timestamp=int(time()), attrs=mapped
                 )
+                refreshed += 1
 
                 _LOGGER.debug(
                     "Fetched state for device %s: %d fields",
@@ -663,7 +656,14 @@ class AwsIotApi:
                     len(mapped),
                 )
 
-            except Exception as err:
+            except AwsIotAuthException as err:
+                auth_failed = True
+                _LOGGER.warning(
+                    "Authentication failure fetching device %s: %s",
+                    device_id[:12],
+                    err,
+                )
+            except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.warning(
                     "Failed to fetch state for device %s: %s", device_id[:12], err
                 )
@@ -672,6 +672,36 @@ class AwsIotApi:
                     self._state_cache[device_id] = BestwayDeviceStatus(
                         timestamp=int(time()), attrs={}
                     )
+
+        return refreshed, auth_failed
+
+    async def fetch_data(self) -> Any:  # Returns BestwayApiResults
+        """Fetch state, refreshing an expired token once before failing."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        from ..bestway.api import BestwayApiResults
+
+        refreshed, auth_failed = await self._poll_all_devices()
+
+        if self.devices and refreshed == 0 and auth_failed:
+            _LOGGER.info("Re-authenticating after auth failure during poll")
+            try:
+                token = await self.authenticate(
+                    self._session, self._visitor_id, self._location, self._api_base
+                )
+            except AwsIotAuthException as err:
+                raise ConfigEntryAuthFailed from err
+            except AwsIotConnectionError as err:
+                raise UpdateFailed(
+                    "Unable to reach Bestway authentication service"
+                ) from err
+
+            self.update_token(token)
+            refreshed, _ = await self._poll_all_devices()
+
+        if self.devices and refreshed == 0:
+            raise UpdateFailed("Unable to refresh any Bestway device state")
 
         return BestwayApiResults(devices=self._state_cache)
 

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -684,7 +684,7 @@ class AwsIotApi:
 
         refreshed, auth_failed = await self._poll_all_devices()
 
-        if self.devices and refreshed == 0 and auth_failed:
+        if self.devices and auth_failed:
             _LOGGER.info("Re-authenticating after auth failure during poll")
             try:
                 token = await self.authenticate(

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -18,7 +18,7 @@ import secrets
 from time import time
 from typing import Any
 
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession
 
 from .encryption import encrypt_command_payload
 from ..bestway.model import (
@@ -34,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_API_BASE = "https://smarthub-eu.bestwaycorp.com"  # EU endpoint
 APP_ID = "AhFLL54HnChhrxcl9ZUJL6QNfolTIB"
 APP_SECRET = "4ECvVs13enL5AiYSmscNjvlaisklQDz7vWPCCWXcEFjhWfTmLT"
-TIMEOUT = 10
+TIMEOUT = 20
 
 # Regional API endpoints (from ServiceConfig.java)
 API_ENDPOINTS = {
@@ -51,6 +51,10 @@ class AwsIotException(Exception):
 
 class AwsIotAuthException(AwsIotException):
     """Authentication error."""
+
+
+class AwsIotConnectionError(AwsIotException):
+    """Transient connection error."""
 
 
 class AwsIotApi:
@@ -215,7 +219,8 @@ class AwsIotApi:
             Authentication token
 
         Raises:
-            AwsIotAuthException: If authentication fails
+            AwsIotAuthException: If authentication is rejected
+            AwsIotConnectionError: If the authentication service cannot be reached
         """
         import random
         import string
@@ -271,20 +276,32 @@ class AwsIotApi:
         _LOGGER.debug("Sign in headers: %s", "sign" in headers)
         _LOGGER.debug("All header keys: %s", list(headers.keys()))
 
-        async with asyncio.timeout(TIMEOUT):
-            async with session.post(
-                url, headers=headers, json=payload, ssl=False
-            ) as resp:
-                data = await resp.json()
-                _LOGGER.debug("Auth response: %s", data)
-                _LOGGER.debug("Response status: %s", resp.status)
-                token = data.get("data", {}).get("token")
+        try:
+            async with asyncio.timeout(TIMEOUT):
+                async with session.post(
+                    url, headers=headers, json=payload, ssl=False
+                ) as resp:
+                    data = await resp.json()
+                    _LOGGER.debug("Auth response: %s", data)
+                    _LOGGER.debug("Response status: %s", resp.status)
 
-                if not token:
-                    _LOGGER.error("No token in response. Full response: %s", data)
-                    raise AwsIotAuthException("No token in authentication response")
+                    if resp.status in (401, 403):
+                        raise AwsIotAuthException("Authentication rejected")
 
-                return str(token)
+                    token = data.get("data", {}).get("token")
+                    if not token:
+                        _LOGGER.error("No token in response. Full response: %s", data)
+                        raise AwsIotAuthException("No token in authentication response")
+
+                    return str(token)
+        except (TimeoutError, ClientError) as err:
+            raise AwsIotConnectionError(
+                "Unable to reach the authentication service"
+            ) from err
+
+    def update_token(self, token: str) -> None:
+        """Replace the token used by subsequent API requests."""
+        self._token = token
 
     @staticmethod
     async def bind_qr_code(

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -308,7 +308,7 @@ class AwsIotApi:
             self._token_update_callback(token)
 
     def set_token_update_callback(self, callback: Callable[[str], None] | None) -> None:
-        """Set a callback for persisting and propagating refreshed tokens."""
+        """Set a callback for propagating refreshed tokens."""
         self._token_update_callback = callback
 
     @staticmethod

--- a/custom_components/bestway/aws_iot/websocket.py
+++ b/custom_components/bestway/aws_iot/websocket.py
@@ -93,6 +93,10 @@ class AwsIotWebSocket:
             )
         return endpoint
 
+    def update_token(self, token: str) -> None:
+        """Replace the token used by the next connection attempt."""
+        self._token = token
+
     async def connect(self) -> None:
         """Connect to region-specific WebSocket endpoint.
 

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -19,7 +19,12 @@ from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 
-from .aws_iot.api import AwsIotAuthException
+from .aws_iot.api import (
+    API_ENDPOINTS,
+    AwsIotApi,
+    AwsIotAuthException,
+    AwsIotConnectionError,
+)
 from .bestway.api import (
     BestwayApi,
     BestwayIncorrectPasswordException,
@@ -137,6 +142,37 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         else:
             return await self.async_step_aws_iot_auth()
 
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Refresh credentials for an existing AWS IoT entry."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None or entry.data.get("backend") != BACKEND_AWS_IOT:
+            return self.async_abort(reason="reauth_unsuccessful")
+
+        visitor_id = entry.data["visitor_id"]
+        location = entry.data.get("location", "GB")
+        api_base = entry.data.get("api_base")
+        if not api_base:
+            api_base = API_ENDPOINTS.get(
+                entry.data.get("region", "EU"), API_ENDPOINTS["EU"]
+            )
+
+        try:
+            token = await AwsIotApi.authenticate(
+                async_get_clientsession(self.hass),
+                visitor_id,
+                location,
+                api_base,
+            )
+        except AwsIotConnectionError:
+            return self.async_abort(reason="cannot_connect")
+        except AwsIotAuthException:
+            return self.async_abort(reason="reauth_unsuccessful")
+
+        return self.async_update_reload_and_abort(
+            entry,
+            data_updates={"token": token},
+        )
+
     async def async_step_gizwits_auth(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -239,8 +275,6 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         try:
-            from .aws_iot.api import AwsIotApi, API_ENDPOINTS
-
             session = async_get_clientsession(self.hass)
 
             # Map region to API endpoint
@@ -340,6 +374,9 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         except AwsIotAuthException as auth_err:
             _LOGGER.error("AWS IoT authentication failed: %s", auth_err)
             errors["base"] = "auth_failed"
+        except AwsIotConnectionError as connection_err:
+            _LOGGER.error("AWS IoT connection failed: %s", connection_err)
+            errors["base"] = "cannot_connect"
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("AWS IoT setup failed")
             errors["base"] = "unknown"

--- a/custom_components/bestway/coordinator.py
+++ b/custom_components/bestway/coordinator.py
@@ -1,6 +1,5 @@
 """Data update coordinator for the Bestway API."""
 
-import asyncio
 from datetime import timedelta
 from logging import getLogger
 from time import time
@@ -47,9 +46,8 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
         This is the place to pre-process the data to lookup tables
         so entities can quickly look up their data.
         """
-        async with asyncio.timeout(10):
-            await self.api.refresh_bindings()
-            return await self.api.fetch_data()
+        await self.api.refresh_bindings()
+        return await self.api.fetch_data()
 
     def handle_websocket_update(self, device_id: str, attrs: dict[str, Any]) -> None:
         """Handle real-time device update from WebSocket.

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -27,6 +27,11 @@
         }
       }
     },
+    "abort": {
+      "cannot_connect": "Could not connect to the Bestway API. Home Assistant will retry setup.",
+      "reauth_successful": "Authentication refreshed successfully.",
+      "reauth_unsuccessful": "Authentication could not be refreshed."
+    },
     "error": {
       "cannot_connect": "Could not connect to the Bestway API",
       "user_does_not_exist": "User account does not exist",

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -28,7 +28,7 @@
       }
     },
     "abort": {
-      "cannot_connect": "Could not connect to the Bestway API. Home Assistant will retry setup.",
+      "cannot_connect": "Could not connect to the Bestway API. Try reloading the integration.",
       "reauth_successful": "Authentication refreshed successfully.",
       "reauth_unsuccessful": "Authentication could not be refreshed."
     },

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -6,6 +6,7 @@ import pytest
 from custom_components.bestway.aws_iot.api import (
     AwsIotApi,
     AwsIotAuthException,
+    AwsIotConnectionError,
 )
 
 
@@ -17,6 +18,26 @@ def create_mock_response(status: int, json_data: dict):
     response.__aenter__ = AsyncMock(return_value=response)
     response.__aexit__ = AsyncMock(return_value=None)
     return response
+
+
+@pytest.mark.asyncio
+async def test_authenticate_wraps_timeout_as_connection_error(mock_session):
+    """Authentication timeouts are classified as transient connection errors."""
+    mock_session.post = MagicMock(side_effect=TimeoutError)
+
+    with pytest.raises(AwsIotConnectionError):
+        await AwsIotApi.authenticate(mock_session, "test_visitor")
+
+
+@pytest.mark.asyncio
+async def test_authenticate_rejects_missing_token(mock_session):
+    """A successful response without a token is an authentication failure."""
+    mock_session.post = MagicMock(
+        return_value=create_mock_response(200, {"code": 1, "data": {}})
+    )
+
+    with pytest.raises(AwsIotAuthException):
+        await AwsIotApi.authenticate(mock_session, "test_visitor")
 
 
 @pytest.fixture

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -375,6 +375,33 @@ async def test_fetch_data_reauthenticates_and_propagates_token(aws_api):
 
 
 @pytest.mark.asyncio
+async def test_fetch_data_reauthenticates_after_partial_auth_failure(aws_api):
+    """Any auth rejection refreshes the shared account token."""
+    aws_api.devices = {
+        "device1": _make_aws_device("device1"),
+        "device2": _make_aws_device("device2"),
+    }
+    shadow = {"code": 0, "data": {"state": {"reported": {"power_state": 1}}}}
+    aws_api._do_post = AsyncMock(
+        side_effect=[
+            shadow,
+            AwsIotAuthException("expired"),
+            shadow,
+            shadow,
+        ]
+    )
+
+    with patch.object(
+        AwsIotApi, "authenticate", new=AsyncMock(return_value="fresh_token")
+    ) as authenticate:
+        results = await aws_api.fetch_data()
+
+    authenticate.assert_awaited_once()
+    assert set(results.devices) == {"device1", "device2"}
+    assert aws_api._do_post.await_count == 4
+
+
+@pytest.mark.asyncio
 async def test_fetch_data_raises_auth_failed_when_reauth_rejected(aws_api):
     """A rejected runtime reauth starts Home Assistant's reauth handling."""
     from homeassistant.exceptions import ConfigEntryAuthFailed

--- a/tests/test_aws_iot_api.py
+++ b/tests/test_aws_iot_api.py
@@ -1,6 +1,6 @@
 """Tests for AWS IoT API client."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.bestway.aws_iot.api import (
@@ -38,6 +38,19 @@ async def test_authenticate_rejects_missing_token(mock_session):
 
     with pytest.raises(AwsIotAuthException):
         await AwsIotApi.authenticate(mock_session, "test_visitor")
+
+
+@pytest.mark.asyncio
+async def test_authenticate_checks_rejection_before_parsing_body(mock_session):
+    """A non-JSON 401 remains an authentication failure."""
+    response = create_mock_response(401, {})
+    response.json.side_effect = Exception("not JSON")
+    mock_session.post = MagicMock(return_value=response)
+
+    with pytest.raises(AwsIotAuthException):
+        await AwsIotApi.authenticate(mock_session, "test_visitor")
+
+    response.json.assert_not_awaited()
 
 
 @pytest.fixture
@@ -323,6 +336,75 @@ async def test_fetch_data_returns_results(aws_api, mock_session):
     assert status.attrs["Tnow"] == 36
 
 
+def _make_aws_device(device_id="device1"):
+    """Build a real AWS IoT device for polling tests."""
+    from custom_components.bestway.bestway.model import BestwayDevice
+
+    return BestwayDevice(
+        protocol_version=2,
+        device_id=device_id,
+        product_name="AIRJET",
+        alias="Test Spa",
+        mcu_soft_version="unknown",
+        mcu_hard_version="unknown",
+        wifi_soft_version="unknown",
+        wifi_hard_version="unknown",
+        is_online=True,
+        backend="aws_iot",
+        product_id="T53NN8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_reauthenticates_and_propagates_token(aws_api):
+    """A poll auth failure refreshes once and propagates the new token."""
+    aws_api.devices = {"device1": _make_aws_device()}
+    shadow = {"code": 0, "data": {"state": {"reported": {"power_state": 1}}}}
+    aws_api._do_post = AsyncMock(side_effect=[AwsIotAuthException("expired"), shadow])
+    token_updated = MagicMock()
+    aws_api.set_token_update_callback(token_updated)
+
+    with patch.object(
+        AwsIotApi, "authenticate", new=AsyncMock(return_value="fresh_token")
+    ):
+        results = await aws_api.fetch_data()
+
+    assert results.devices["device1"].attrs["power"] is True
+    assert aws_api._token == "fresh_token"
+    token_updated.assert_called_once_with("fresh_token")
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_raises_auth_failed_when_reauth_rejected(aws_api):
+    """A rejected runtime reauth starts Home Assistant's reauth handling."""
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+
+    aws_api.devices = {"device1": _make_aws_device()}
+    aws_api._do_post = AsyncMock(side_effect=AwsIotAuthException("expired"))
+
+    with (
+        patch.object(
+            AwsIotApi,
+            "authenticate",
+            new=AsyncMock(side_effect=AwsIotAuthException("rejected")),
+        ),
+        pytest.raises(ConfigEntryAuthFailed),
+    ):
+        await aws_api.fetch_data()
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_raises_update_failed_on_total_connection_failure(aws_api):
+    """A total poll failure makes entities unavailable instead of stale."""
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+
+    aws_api.devices = {"device1": _make_aws_device()}
+    aws_api._do_post = AsyncMock(side_effect=ConnectionError("offline"))
+
+    with pytest.raises(UpdateFailed):
+        await aws_api.fetch_data()
+
+
 @pytest.mark.asyncio
 async def test_set_device_state_sends_command(aws_api, mock_session):
     """Test control command sends encrypted payload."""
@@ -366,3 +448,16 @@ async def test_do_get_handles_401(aws_api, mock_session):
 
     with pytest.raises(AwsIotAuthException):
         await aws_api._do_get("/test")
+
+
+@pytest.mark.asyncio
+async def test_do_post_checks_auth_status_before_parsing_body(aws_api, mock_session):
+    """A non-JSON auth rejection still triggers runtime reauthentication."""
+    response = create_mock_response(401, {})
+    response.json.side_effect = Exception("not JSON")
+    mock_session.post = MagicMock(return_value=response)
+
+    with pytest.raises(AwsIotAuthException):
+        await aws_api._do_post("/test", {})
+
+    response.json.assert_not_awaited()

--- a/tests/test_aws_iot_websocket.py
+++ b/tests/test_aws_iot_websocket.py
@@ -224,6 +224,13 @@ async def test_region_fallback_to_eu(aws_websocket):
     assert "eu-central-1" in url
 
 
+def test_update_token_changes_next_connection_token(aws_websocket):
+    """Token updates are applied to subsequent WebSocket connections."""
+    aws_websocket.update_token("fresh_token")
+
+    assert aws_websocket._token == "fresh_token"
+
+
 @pytest.mark.asyncio
 async def test_heartbeat_loop_sends_messages(aws_websocket):
     """Test heartbeat loop sends JSON heartbeat and WebSocket ping."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,9 +7,11 @@ from unittest.mock import patch
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.bestway.bestway.model import BestwayUserToken
 from custom_components.bestway.const import (
+    BACKEND_AWS_IOT,
     CONF_API_ROOT,
     CONF_API_ROOT_EU,
     CONF_PASSWORD,
@@ -210,3 +212,39 @@ async def test_backend_selection_shows_both_options(hass):
     # Schema should have backend field with options
     schema_keys = list(result["data_schema"].schema.keys())
     assert any("backend" in str(key) for key in schema_keys)
+
+
+async def test_aws_iot_reauth_refreshes_token(hass):
+    """AWS IoT reauth uses the stored visitor ID without user input."""
+    entry = MockConfigEntry(
+        version=2,
+        domain=DOMAIN,
+        title="Bestway Spa",
+        data={
+            "backend": BACKEND_AWS_IOT,
+            "visitor_id": "test_visitor",
+            "token": "old_token",
+            "region": "EU",
+            "api_base": "https://example.test",
+        },
+        source=config_entries.SOURCE_USER,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.bestway.config_flow.AwsIotApi.authenticate",
+        return_value="new_token",
+    ) as authenticate:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+            data=dict(entry.data),
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data["token"] == "new_token"
+    authenticate.assert_awaited_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,17 @@
 """Test bestway setup process."""
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.bestway import (
     BestwayUpdateCoordinator,
+    _async_setup_aws_iot,
 )
 from custom_components.bestway.bestway.model import BestwayUserToken
 from custom_components.bestway.const import (
@@ -20,6 +23,10 @@ from custom_components.bestway.const import (
     CONF_USER_TOKEN_EXPIRY,
     CONF_USERNAME,
     DOMAIN,
+)
+from custom_components.bestway.aws_iot.api import (
+    AwsIotAuthException,
+    AwsIotConnectionError,
 )
 
 
@@ -129,3 +136,42 @@ async def test_setup_entry_exception(hass: HomeAssistant, error_on_get_data):
 
     await hass.async_block_till_done()
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+def _aws_iot_entry() -> MockConfigEntry:
+    """Create an AWS IoT config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "backend": "aws_iot",
+            "visitor_id": "test_visitor",
+            "region": "EU",
+            "api_base": "https://example.test",
+        },
+        version=2,
+        entry_id="aws-iot-test",
+    )
+
+
+async def test_aws_iot_setup_retries_connection_failure(hass: HomeAssistant):
+    """A transient startup auth failure is mapped to ConfigEntryNotReady."""
+    config_entry = _aws_iot_entry()
+
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.authenticate",
+        side_effect=AwsIotConnectionError,
+    ):
+        with pytest.raises(ConfigEntryNotReady):
+            await _async_setup_aws_iot(hass, config_entry, AsyncMock())
+
+
+async def test_aws_iot_setup_maps_rejection_to_auth_failure(hass: HomeAssistant):
+    """A definitive startup auth rejection is mapped to an auth failure."""
+    config_entry = _aws_iot_entry()
+
+    with patch(
+        "custom_components.bestway.aws_iot.api.AwsIotApi.authenticate",
+        side_effect=AwsIotAuthException,
+    ):
+        with pytest.raises(ConfigEntryAuthFailed):
+            await _async_setup_aws_iot(hass, config_entry, AsyncMock())

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 """Test bestway setup process."""
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -175,3 +175,46 @@ async def test_aws_iot_setup_maps_rejection_to_auth_failure(hass: HomeAssistant)
     ):
         with pytest.raises(ConfigEntryAuthFailed):
             await _async_setup_aws_iot(hass, config_entry, AsyncMock())
+
+
+async def test_runtime_token_refresh_does_not_update_config_entry(
+    hass: HomeAssistant,
+):
+    """Runtime token refresh avoids triggering the entry reload listener."""
+    config_entry = _aws_iot_entry()
+    config_entry.add_to_hass(hass)
+
+    async def refresh_token_during_first_refresh(coordinator):
+        coordinator.api.update_token("runtime_token")
+
+    with (
+        patch(
+            "custom_components.bestway.aws_iot.api.AwsIotApi.authenticate",
+            return_value="startup_token",
+        ),
+        patch.object(
+            BestwayUpdateCoordinator,
+            "async_config_entry_first_refresh",
+            refresh_token_during_first_refresh,
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_forward_entry_setups",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            hass.config_entries,
+            "async_update_entry",
+            wraps=hass.config_entries.async_update_entry,
+        ) as update_entry,
+    ):
+        await _async_setup_aws_iot(hass, config_entry, AsyncMock())
+
+        coordinator = hass.data[DOMAIN][config_entry.entry_id]
+        websocket = MagicMock()
+        coordinator.websockets.append(websocket)
+        coordinator.api.update_token("later_runtime_token")
+
+    update_entry.assert_called_once()
+    assert config_entry.data["token"] == "startup_token"
+    websocket.update_token.assert_called_once_with("later_runtime_token")


### PR DESCRIPTION
## What this is now

Rebased onto current `main` (`f6c66a8`, `v1.11.1`) and re-scoped to one thing: **V02 authentication failures should be recoverable without a manual reload.**

This is the split you suggested in [your closing review comment](https://github.com/cdpuk/ha-bestway/pull/124#discussion_r3523814049) — *"if that proves to be problematic, I suggest raising the authentication fix as a separate PR - this is clearly a sensible thing on its own."* The convergence work ("Fix B") is gone and is not coming back in this PR; it still has the unresolved false-positive problem with rapid commands that you identified, and it belongs in its own change.

## Why now: the defect is still live on v1.11.1

[#176](https://github.com/cdpuk/ha-bestway/issues/176) reports it against `1.11.1`, and the log in that issue is an exact trace of three of the fixes here:

```
09:27:45.043  Authenticating visitor **REDACTED**
09:27:55.079  ERROR ... Error setting up entry Bestway Spa (V02 - EU) for bestway
              asyncio.exceptions.CancelledError
```

That is 10.036 seconds — `asyncio.timeout(TIMEOUT)` with `TIMEOUT = 10`. The `TimeoutError` then escapes `async_setup_entry`, so the entry lands in `SETUP_ERROR`, which Home Assistant never retries. Hence the reporter's summary: *"After the reboot I have to manually reload the Bestway integration."*

The same defect recurred on a second installation on 2026-09-17 and 2026-09-18.

## The changes

**Classify at the API boundary**

- `AwsIotConnectionError` for a cloud that could not be reached, distinct from `AwsIotAuthException` for one that refused the credentials. Callers no longer guess from whatever aiohttp or asyncio raised underneath.
- **Status is checked before the body is parsed** — on the login path and both authenticated request paths. A rejection is not always JSON, and parsing first turned a definitive 401/403 into a `ContentTypeError`, which is a `ClientError`, and would therefore be classified as transient and retried forever against credentials that had already been refused. `403` now counts as a rejection alongside `400`/`401`.
- `TIMEOUT` 10s → 20s. This matches `smartspa/api.py`, which already carries `TIMEOUT = 20  # the gateway can be slow; 10s caused spurious failures upstream`. #176 is the same symptom on the AWS IoT path.

**Act on the classification**

- Setup maps an unreachable cloud to `ConfigEntryNotReady` (retried with backoff) and a rejection to `ConfigEntryAuthFailed` (starts reauth). Previously either one parked the entry in `SETUP_ERROR`.
- A rejected poll re-authenticates once and polls again, recovering within a single cycle.
- A poll where **no** device refreshed raises, so entities go unavailable rather than continuing to serve cached state. This is the reason a dead session used to look healthy for hours.
- The coordinator translates these into `ConfigEntryAuthFailed`/`UpdateFailed`, alongside the existing SmartSpa handling, which keeps Home Assistant's exception vocabulary out of the API clients.

**Propagate a refreshed token in memory**

`AwsIotApi.update_token()` replaces the token and notifies a callback, so the per-device WebSockets get it before they next reconnect — otherwise they keep retrying with the token that was just rejected. It is deliberately **not** written back to the config entry: that fires the entry's update listener, which reloads the integration out from under the coordinator update that just refreshed the token. The stored token is only a startup hint, since setup always authenticates afresh.

**A reauth flow for V02 entries**

V02 auth derives a token from the stored `visitor_id` alone, so there is nothing to ask the user for and the flow completes without showing a form.

## Decision: the coordinator's aggregate timeout is removed

Flagging this explicitly rather than letting it look like a merge artefact.

`main` has `async with asyncio.timeout(30)` around the whole poll cycle. All three backends already bound **every individual HTTP call** (`asyncio.timeout(TIMEOUT)` in `bestway/api.py`, `aws_iot/api.py`, `smartspa/api.py`), so nothing in the cycle can hang indefinitely — the cap is not a hang guard.

What it does do is cut short the recovery paths. At 20s per call, a reauthenticate-and-repoll cycle on a modest account is `refresh_bindings` (3+ GETs) + 1 POST per device + 1 auth POST + 1 POST per device — six sequential calls for a single-device account, so up to 120s. Any cap that reliably covers that is far longer than the 30s poll interval, which makes it meaningless. The honest options were "remove it" or "raise it to a number so large it is not a timeout"; I took the first.

This also removes a latent cap on SmartSpa: its own re-login-and-retry is up to three calls at `TIMEOUT = 20`, i.e. 60s, which the existing 30s cap could already guillotine.

## Relationship to #177

[#177](https://github.com/cdpuk/ha-bestway/pull/177) implements the startup-retry slice (AWS IoT + SmartSpa) against current `main`, and is the smaller change. The two overlap on one line — mapping a transient AWS IoT login failure to `ConfigEntryNotReady`.

They are **not** redundant in both directions:

- This PR does not touch SmartSpa, so #177's SmartSpa half is additive either way.
- #177 alone is not sufficient for the AWS IoT path: without the status-before-body ordering here, a non-JSON 401/403 surfaces as `ContentTypeError` → `ClientError` → classified transient → retried forever against credentials the cloud has already refused.

Whichever lands first, the other is a small rebase. If you would prefer #177 to land first, say so and I will rebase this on top of it and drop the overlapping line.

## Your review threads

Re-read all seven. Not marking any resolved — that is yours to do.

| Thread | Status |
|---|---|
| `api.py` — *"Should this include `refreshed == 0`? ... `if self.devices and auth_failed:`"* | **Applied.** That is the exact condition now. `test_fetch_data_reauthenticates_after_partial_auth_failure` pins it: device 1 succeeds, device 2 is rejected, reauth still happens. |
| `api.py` — *reference to `bestway-fix-b-command-convergence.md`, other "Fix B" references* | **Gone.** `git grep -i -E 'fix.b\|convergence\|command_verif\|bestway-fix'` over `custom_components` and `tests` returns nothing. |
| `api.py` — *convergence comment hard to read ("toggle field", "echo field", "reporting progress")* | **Moot** — that code is not in this PR. |
| `coordinator.py` — *"Spa Tier C" references need removing* | **Gone**, same grep. |
| `api.py` — *design issue: rapid commands cause false-positive convergence checks* | **Not addressed, deliberately.** Your timeline is correct and unresolved. It is why convergence is out of scope here. |
| `const.py` — *the added event isn't core to the fix; use the existing `connected` entity* | **Gone.** No event or new const is added. |
| `api.py` — *"raise the authentication fix as a separate PR - clearly a sensible thing on its own"* | **This is that PR.** |

## Validation

Run in a `python3.14` container reproducing `.github/workflows/test.yaml` and `pre-commit.yaml` exactly.

| Gate | `origin/main` baseline | This branch |
|---|---|---|
| `pytest` (CI command) | 289 passed, exit 0 | **318 passed, exit 0** |
| `pre-commit run --all-files` | all Passed, exit 0 | **all Passed, exit 0** (actionlint, ruff-check, ruff-format, codespell, check-json, yamllint, prettier, mypy) |

The 29 new tests were each checked against **unpatched** source, by reverting one file or mutating one behaviour at a time and confirming the intended tests — and only those — fail:

| Reverted / mutated | Tests that fail |
|---|---|
| `websocket_base.py` | `test_update_token_is_used_by_the_next_connection` |
| `coordinator.py` | `test_coordinator_maps_aws_iot_auth_failure_to_reauth`, `..._to_update_failed` |
| `config_flow.py` | 4 reauth tests + `test_aws_iot_setup_starts_reauth_when_login_rejected` |
| `__init__.py` | `test_aws_iot_setup_retries_when_cloud_unreachable`, `test_runtime_token_refresh_reaches_websockets_without_reloading` |
| `authenticate`: parse body before status | `test_authenticate_checks_rejection_before_parsing_body` (401, 403) |
| `authenticate`: drop the transient wrap | `test_authenticate_wraps_timeout_as_connection_error`, `test_authenticate_wraps_an_expired_deadline` |
| `_do_get` / `_do_post`: parse first, drop 403 | `test_do_get_...`, `test_do_post_checks_auth_status_before_parsing_body` (400, 401, 403) |
| `fetch_data`: never re-authenticate | the 4 reauth tests |
| `fetch_data`: return cache when nothing refreshed | `test_fetch_data_raises_when_no_device_refreshes` |
| `update_token`: skip the callback | `test_fetch_data_reauthenticates_and_propagates_token`, `test_runtime_token_refresh_reaches_websockets_without_reloading` |

`test_authenticate_wraps_an_expired_deadline` drives a real expiring `asyncio.timeout` rather than a mock raising `TimeoutError`, because the conversion from `CancelledError` only happens as the timeout block unwinds — which is what #176's traceback actually shows, and what decides whether the `except` is placed correctly.

Two honest gaps: `TIMEOUT = 20` has no regression test, since a timeout constant has no observable behaviour under mocked I/O; and removing the coordinator's aggregate timeout has none either, since proving it would need a >30s test against a suite that runs `--timeout=9`.

## Note on the commits

The four original commits were collapsed into one. Twelve upstream commits landed since the old base — including the `BackendApi` protocol, typed `DeviceStatus`, feature-based entity selection and the redaction pass — and the old slices no longer mapped onto the current code, so re-expressing them separately would have meant inventing a history that never existed. The pre-rebase head is preserved at `hugo-brito/ha-bestway@archive/pr124-pre-rebase`.
