### PR TITLE
Improve auth token handling for v2

### DIFF
--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -226,6 +226,13 @@ async def _async_setup_aws_iot(
     except AwsIotAuthException as ex:
         _LOGGER.error("AWS IoT authentication failed: %s", ex)
         raise ConfigEntryAuthFailed from ex
+    except Exception as ex:  # pylint: disable=broad-except
+        # Network/DNS hiccups (common at HA startup before networking is
+        # fully up) surface as TimeoutError/ClientConnectionError, not
+        # AwsIotAuthException. Treat those as transient so HA retries setup
+        # with backoff instead of failing the entry outright.
+        _LOGGER.warning("AWS IoT setup failed, will retry: %s", ex)
+        raise ConfigEntryNotReady from ex
 
     async def _refresh_aws_token() -> str:
         """Obtain a fresh token when the server rejects the current one.

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -106,7 +106,35 @@ async def _async_setup_gizwits(
         )
 
     api = BestwayApi(session, user_token, api_root)
-    coordinator = BestwayUpdateCoordinator(hass, entry, api)
+
+    async def _refresh_gizwits_token() -> str:
+        """Obtain a fresh token when the server rejects the current one.
+
+        Cloud tokens can be invalidated server-side without warning. This
+        re-authenticates with the stored credentials and updates the API
+        instance and config entry in place so the next poll/reconnect uses
+        the new token. Raises if the credentials themselves are no longer
+        valid (e.g. password changed), which the caller converts to
+        ConfigEntryAuthFailed to trigger HA's reauth flow.
+        """
+        new_token = await BestwayApi.get_user_token(
+            session, username, password, api_root
+        )
+        api._user_token = new_token.user_token
+        hass.config_entries.async_update_entry(
+            entry,
+            data={
+                **entry.data,
+                CONF_USER_TOKEN: new_token.user_token,
+                CONF_USER_TOKEN_EXPIRY: new_token.expiry,
+                CONF_UID: new_token.user_id,
+            },
+        )
+        return new_token.user_token
+
+    coordinator = BestwayUpdateCoordinator(
+        hass, entry, api, reauth_callback=_refresh_gizwits_token
+    )
     await coordinator.async_config_entry_first_refresh()
 
     # Initialize WebSocket for real-time updates
@@ -126,6 +154,7 @@ async def _async_setup_gizwits(
                     ws_port=first_device.ws_port,
                     update_callback=coordinator.handle_websocket_update,
                     disconnect_callback=coordinator.handle_websocket_disconnect,
+                    token_refresh_callback=_refresh_gizwits_token,
                 )
 
                 # Connect in background
@@ -198,8 +227,27 @@ async def _async_setup_aws_iot(
         _LOGGER.error("AWS IoT authentication failed: %s", ex)
         raise ConfigEntryAuthFailed from ex
 
+    async def _refresh_aws_token() -> str:
+        """Obtain a fresh token when the server rejects the current one.
+
+        Shared by the coordinator (for REST polling) and every per-device
+        WebSocket, so a single re-authentication call recovers all of them.
+        Raises AwsIotAuthException if the visitor_id itself is no longer
+        valid, which the coordinator converts to ConfigEntryAuthFailed.
+        """
+        new_token = await AwsIotApi.authenticate(
+            session, visitor_id, location, api_base
+        )
+        api._token = new_token
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "token": new_token}
+        )
+        return new_token
+
     # Initialize coordinator
-    coordinator = BestwayUpdateCoordinator(hass, entry, api)
+    coordinator = BestwayUpdateCoordinator(
+        hass, entry, api, reauth_callback=_refresh_aws_token
+    )
     await coordinator.async_config_entry_first_refresh()
 
     # Initialize per-device WebSockets
@@ -207,24 +255,13 @@ async def _async_setup_aws_iot(
     if api.devices:
         for device_id, device in api.devices.items():
             try:
-                # Token refresh callback
-                async def token_refresh_callback() -> str:
-                    new_token = await AwsIotApi.authenticate(
-                        session, visitor_id, location, api_base
-                    )
-                    api._token = new_token
-                    hass.config_entries.async_update_entry(
-                        entry, data={**entry.data, "token": new_token}
-                    )
-                    return new_token
-
                 ws = AwsIotWebSocket(
                     device_id=device_id,
                     service_region=device.ws_host,  # Region stored in ws_host
                     token=token,
                     update_callback=coordinator.handle_websocket_update,
                     disconnect_callback=coordinator.handle_websocket_disconnect,
-                    token_refresh_callback=token_refresh_callback,
+                    token_refresh_callback=_refresh_aws_token,
                 )
 
                 # Connect in background

--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -231,7 +231,9 @@ async def _async_setup_aws_iot(
         # fully up) surface as TimeoutError/ClientConnectionError, not
         # AwsIotAuthException. Treat those as transient so HA retries setup
         # with backoff instead of failing the entry outright.
-        _LOGGER.warning("AWS IoT setup failed, will retry: %s", ex)
+        _LOGGER.warning(
+            "AWS IoT setup failed, will retry: %s: %s", type(ex).__name__, ex
+        )
         raise ConfigEntryNotReady from ex
 
     async def _refresh_aws_token() -> str:

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -34,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_API_BASE = "https://smarthub-eu.bestwaycorp.com"  # EU endpoint
 APP_ID = "AhFLL54HnChhrxcl9ZUJL6QNfolTIB"
 APP_SECRET = "4ECvVs13enL5AiYSmscNjvlaisklQDz7vWPCCWXcEFjhWfTmLT"
-TIMEOUT = 10
+TIMEOUT = 20
 
 # Regional API endpoints (from ServiceConfig.java)
 API_ENDPOINTS = {

--- a/custom_components/bestway/aws_iot/api.py
+++ b/custom_components/bestway/aws_iot/api.py
@@ -646,6 +646,12 @@ class AwsIotApi:
                     len(mapped),
                 )
 
+            except AwsIotAuthException:
+                # Let auth failures propagate so the coordinator can refresh
+                # the token and retry, instead of silently leaving every
+                # device stuck on stale cached data until the token happens
+                # to be refreshed on the next HA restart.
+                raise
             except Exception as err:
                 _LOGGER.warning(
                     "Failed to fetch state for device %s: %s", device_id[:12], err

--- a/custom_components/bestway/bestway/api.py
+++ b/custom_components/bestway/bestway/api.py
@@ -29,7 +29,7 @@ _HEADERS = {
     "Content-type": "application/json; charset=UTF-8",
     "X-Gizwits-Application-Id": GIZWITS_APP_ID,
 }
-_TIMEOUT = 10
+_TIMEOUT = 20
 
 
 @dataclass

--- a/custom_components/bestway/bestway/websocket.py
+++ b/custom_components/bestway/bestway/websocket.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from logging import getLogger
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 
 import websockets
 
@@ -17,6 +17,10 @@ _RECONNECT_DELAYS = [3, 6, 12, 24, 48, 60]
 
 class GizwitsWebSocketException(Exception):
     """Base exception for WebSocket operations."""
+
+
+class GizwitsWebSocketAuthException(GizwitsWebSocketException):
+    """The server rejected the login attempt (invalid/expired token)."""
 
 
 class GizwitsWebSocket:
@@ -38,6 +42,7 @@ class GizwitsWebSocket:
         ws_port: int,
         update_callback: Callable[[str, dict[str, Any]], None],
         disconnect_callback: Callable[[], None] | None = None,
+        token_refresh_callback: Callable[[], Awaitable[str]] | None = None,
     ) -> None:
         """Initialize WebSocket client.
 
@@ -48,12 +53,15 @@ class GizwitsWebSocket:
             ws_port: WebSocket port (from device bindings response)
             update_callback: Called with (device_id, attrs) on device updates
             disconnect_callback: Called on connection loss (optional)
+            token_refresh_callback: Called to obtain a fresh token when the
+                server rejects login with the current one (optional)
         """
         self._uid = uid
         self._token = token
         self._ws_url = f"wss://{ws_host}:{ws_port}/ws/app/v1"
         self._update_callback = update_callback
         self._disconnect_callback = disconnect_callback
+        self._token_refresh_callback = token_refresh_callback
 
         self._websocket: Any = None
         self._listen_task: asyncio.Task[Any] | None = None
@@ -111,7 +119,7 @@ class GizwitsWebSocket:
 
             if not data.get("data", {}).get("success"):
                 error_msg = data.get("data", {}).get("msg", "Unknown error")
-                raise GizwitsWebSocketException(f"Login failed: {error_msg}")
+                raise GizwitsWebSocketAuthException(f"Login failed: {error_msg}")
 
             self._authenticated = True
             self._running = True
@@ -126,6 +134,23 @@ class GizwitsWebSocket:
         except Exception as ex:
             _LOGGER.error("Failed to connect to WebSocket: %s", ex)
             await self.disconnect()
+
+            # Handle a rejected login by refreshing the token and retrying
+            # immediately, rather than reconnecting forever with a token
+            # the server has already rejected.
+            if (
+                isinstance(ex, GizwitsWebSocketAuthException)
+                and self._token_refresh_callback is not None
+            ):
+                try:
+                    new_token = await self._token_refresh_callback()
+                    if new_token:
+                        self._token = new_token
+                        _LOGGER.info("Token refreshed, retrying WebSocket connection")
+                        await self.connect()
+                        return
+                except Exception as refresh_err:  # pylint: disable=broad-except
+                    _LOGGER.error("Token refresh failed: %s", refresh_err)
 
             # Schedule reconnection if still intended to be running
             if not isinstance(ex, asyncio.CancelledError):

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -456,7 +456,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is None and visitor_id:
             # Retry with the existing visitor_id before asking the user for one
             try:
-                token = await AwsIotApi.authenticate(
+                retry_token = await AwsIotApi.authenticate(
                     session, visitor_id, location, api_base
                 )
             except Exception as ex:  # pylint: disable=broad-except
@@ -470,7 +470,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="reauth_entry_not_found")
                 return self.async_update_reload_and_abort(
                     reauth_entry,
-                    data={**self._reauth_data, "token": token},
+                    data={**self._reauth_data, "token": retry_token},
                 )
 
         if user_input is not None:

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from logging import getLogger
 
+from collections.abc import Mapping
 from typing import Any
 
 from aiohttp import ClientConnectionError
@@ -91,6 +92,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize config flow."""
         super().__init__()
         self._backend: str | None = None
+        self._reauth_data: Mapping[str, Any] | None = None
 
     @staticmethod
     @callback
@@ -365,6 +367,182 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle a reauthentication flow.
+
+        Triggered when the coordinator can no longer refresh the auth
+        token automatically (e.g. the account password changed, or the
+        AWS IoT visitor_id was revoked). Normal token expiry - which cloud
+        tokens do silently, every few days - is now handled transparently
+        by the coordinator/websocket clients and never reaches this step.
+        """
+        self._reauth_data = entry_data
+        backend = entry_data.get("backend", BACKEND_GIZWITS)
+        if backend == BACKEND_AWS_IOT:
+            return await self.async_step_reauth_aws_iot()
+        return await self.async_step_reauth_gizwits()
+
+    async def async_step_reauth_gizwits(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication for the Gizwits (V01) backend."""
+        assert self._reauth_data is not None
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                config_entry_data = await validate_input(
+                    self.hass,
+                    {
+                        CONF_USERNAME: self._reauth_data[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_API_ROOT: self._reauth_data[CONF_API_ROOT],
+                    },
+                )
+            except BestwayUserDoesNotExistException:
+                errors["base"] = "user_does_not_exist"
+            except BestwayIncorrectPasswordException:
+                errors["base"] = "incorrect_password"
+            except ClientConnectionError:
+                errors["base"] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown_connection_error"
+            else:
+                reauth_entry = self._get_reauth_entry_or_none()
+                if reauth_entry is None:
+                    return self.async_abort(reason="reauth_entry_not_found")
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data={**self._reauth_data, **config_entry_data},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_gizwits",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={
+                "username": str(self._reauth_data.get(CONF_USERNAME, ""))
+            },
+            errors=errors,
+        )
+
+    async def async_step_reauth_aws_iot(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication for the AWS IoT (V02) backend.
+
+        The visitor_id itself rarely goes bad - only the token does, and
+        that refresh is now handled automatically during normal operation.
+        This step only runs once that automatic refresh has already failed,
+        so first retry it here in case the failure was transient, then fall
+        back to letting the user supply a new visitor_id/QR code.
+        """
+        assert self._reauth_data is not None
+        errors: dict[str, str] = {}
+        session = async_get_clientsession(self.hass)
+
+        from .aws_iot.api import API_ENDPOINTS, AwsIotApi
+
+        visitor_id = str(self._reauth_data.get("visitor_id", ""))
+        location = self._reauth_data.get("location", "GB")
+        region = self._reauth_data.get("region", "EU")
+        api_base = self._reauth_data.get("api_base") or API_ENDPOINTS.get(
+            region, API_ENDPOINTS["EU"]
+        )
+
+        if user_input is None and visitor_id:
+            # Retry with the existing visitor_id before asking the user for one
+            try:
+                token = await AwsIotApi.authenticate(
+                    session, visitor_id, location, api_base
+                )
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.warning(
+                    "Automatic AWS IoT reauth failed, asking for a new visitor ID: %s",
+                    ex,
+                )
+            else:
+                reauth_entry = self._get_reauth_entry_or_none()
+                if reauth_entry is None:
+                    return self.async_abort(reason="reauth_entry_not_found")
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data={**self._reauth_data, "token": token},
+                )
+
+        if user_input is not None:
+            qr_code = user_input.get("qr_code", "").strip()
+            visitor_id_input = user_input.get("visitor_id", "").strip()
+            token = None
+
+            if not qr_code and not visitor_id_input:
+                errors["base"] = "qr_or_visitor_required"
+            else:
+                try:
+                    if qr_code:
+                        if not qr_code.startswith("RW_Share_"):
+                            errors["qr_code"] = "invalid_qr_format"
+                        else:
+                            new_visitor_id = AwsIotApi.generate_visitor_id()
+                            token = await AwsIotApi.authenticate(
+                                session, new_visitor_id, api_base=api_base
+                            )
+                            device_info = await AwsIotApi.bind_qr_code(
+                                session,
+                                qr_code,
+                                new_visitor_id,
+                                token,
+                                api_base=api_base,
+                            )
+                            if not device_info:
+                                errors["qr_code"] = "binding_failed"
+                            else:
+                                visitor_id = new_visitor_id
+                    else:
+                        visitor_id = visitor_id_input
+                        token = await AwsIotApi.authenticate(
+                            session, visitor_id, api_base=api_base
+                        )
+                except AwsIotAuthException as auth_err:
+                    _LOGGER.error("AWS IoT reauth failed: %s", auth_err)
+                    errors["base"] = "auth_failed"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("AWS IoT reauth failed")
+                    errors["base"] = "unknown"
+
+                if not errors and token:
+                    reauth_entry = self._get_reauth_entry_or_none()
+                    if reauth_entry is None:
+                        return self.async_abort(reason="reauth_entry_not_found")
+                    return self.async_update_reload_and_abort(
+                        reauth_entry,
+                        data={
+                            **self._reauth_data,
+                            "visitor_id": visitor_id,
+                            "token": token,
+                        },
+                    )
+
+        return self.async_show_form(
+            step_id="reauth_aws_iot",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional("visitor_id"): str,
+                    vol.Optional("qr_code"): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    def _get_reauth_entry_or_none(self) -> ConfigEntry | None:
+        """Return the config entry being reauthenticated, if it still exists."""
+        entry_id = self.context.get("entry_id")
+        if entry_id is None:
+            return None
+        return self.hass.config_entries.async_get_entry(entry_id)
 
 
 class BestwayOptionsFlowHandler(OptionsFlow):

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -476,7 +476,7 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             qr_code = user_input.get("qr_code", "").strip()
             visitor_id_input = user_input.get("visitor_id", "").strip()
-            token = None
+            token: str | None = None
 
             if not qr_code and not visitor_id_input:
                 errors["base"] = "qr_or_visitor_required"

--- a/custom_components/bestway/coordinator.py
+++ b/custom_components/bestway/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for the Bestway API."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from logging import getLogger
 from time import time
@@ -8,11 +9,12 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .aws_iot.api import AwsIotApi
+from .aws_iot.api import AwsIotApi, AwsIotAuthException
 from .aws_iot.websocket import AwsIotWebSocket
-from .bestway.api import BestwayApi, BestwayApiResults
+from .bestway.api import BestwayApi, BestwayApiResults, BestwayAuthException
 from .bestway.model import BestwayDeviceStatus
 from .bestway.websocket import GizwitsWebSocket
 
@@ -27,8 +29,17 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
         hass: HomeAssistant,
         config_entry: ConfigEntry,
         api: BestwayApi | AwsIotApi,
+        reauth_callback: Callable[[], Awaitable[Any]] | None = None,
     ) -> None:
-        """Initialize my coordinator."""
+        """Initialize my coordinator.
+
+        Args:
+            reauth_callback: Called to obtain a fresh auth token when the API
+                reports the current one is invalid. Should update the API
+                instance and config entry in place, or raise if credentials
+                are no longer valid (e.g. password changed), which converts
+                to ConfigEntryAuthFailed and triggers HA's reauth flow.
+        """
         super().__init__(
             hass,
             _LOGGER,
@@ -37,6 +48,7 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
             update_interval=timedelta(seconds=30),
         )
         self.api = api
+        self._reauth_callback = reauth_callback
         self._ws_last_update: dict[str, float] = {}  # Track WebSocket update times
         self.websocket: GizwitsWebSocket | None = None
         self.websockets: list[AwsIotWebSocket] = []
@@ -47,9 +59,46 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
         This is the place to pre-process the data to lookup tables
         so entities can quickly look up their data.
         """
-        async with asyncio.timeout(10):
-            await self.api.refresh_bindings()
-            return await self.api.fetch_data()
+        try:
+            async with asyncio.timeout(10):
+                await self.api.refresh_bindings()
+                return await self.api.fetch_data()
+        except (BestwayAuthException, AwsIotAuthException) as err:
+            return await self._async_handle_auth_failure(err)
+
+    async def _async_handle_auth_failure(
+        self, original_err: Exception
+    ) -> BestwayApiResults:
+        """Attempt to recover from an auth token that the server has invalidated.
+
+        Cloud tokens can expire or be revoked server-side without warning
+        (observed after a couple of days of continuous use). Rather than
+        failing silently forever and leaving entities unavailable until the
+        user removes and re-adds the integration, try to obtain a fresh
+        token and retry once. Only genuine credential failures escalate to
+        ConfigEntryAuthFailed, which prompts HA's reauth flow. The retry
+        gets its own timeout budget, separate from the failed first attempt.
+        """
+        if self._reauth_callback is None:
+            raise ConfigEntryAuthFailed from original_err
+
+        _LOGGER.warning(
+            "Auth token rejected by server, attempting to refresh: %s", original_err
+        )
+        try:
+            await self._reauth_callback()
+        except Exception as reauth_err:  # pylint: disable=broad-except
+            _LOGGER.error("Failed to refresh auth token: %s", reauth_err)
+            raise ConfigEntryAuthFailed from reauth_err
+
+        try:
+            async with asyncio.timeout(10):
+                await self.api.refresh_bindings()
+                return await self.api.fetch_data()
+        except (BestwayAuthException, AwsIotAuthException) as err:
+            # Refreshed token was rejected again - credentials are stale
+            _LOGGER.error("Refreshed auth token was also rejected: %s", err)
+            raise ConfigEntryAuthFailed from err
 
     def handle_websocket_update(self, device_id: str, attrs: dict[str, Any]) -> None:
         """Handle real-time device update from WebSocket.

--- a/custom_components/bestway/coordinator.py
+++ b/custom_components/bestway/coordinator.py
@@ -20,6 +20,13 @@ from .bestway.websocket import GizwitsWebSocket
 
 _LOGGER = getLogger(__name__)
 
+# Wraps refresh_bindings() + fetch_data(), which makes one HTTP call per
+# device sequentially. Each individual call already has its own internal
+# timeout (see TIMEOUT/_TIMEOUT in the api modules); this outer budget just
+# needs enough headroom to cover a full multi-device cycle without being
+# the thing that fails first on a slow connection.
+_UPDATE_TIMEOUT = 30
+
 
 class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
     """Update coordinator that polls the device status for all devices in an account."""
@@ -60,7 +67,7 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
         so entities can quickly look up their data.
         """
         try:
-            async with asyncio.timeout(10):
+            async with asyncio.timeout(_UPDATE_TIMEOUT):
                 await self.api.refresh_bindings()
                 return await self.api.fetch_data()
         except (BestwayAuthException, AwsIotAuthException) as err:
@@ -92,7 +99,7 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
             raise ConfigEntryAuthFailed from reauth_err
 
         try:
-            async with asyncio.timeout(10):
+            async with asyncio.timeout(_UPDATE_TIMEOUT):
                 await self.api.refresh_bindings()
                 return await self.api.fetch_data()
         except (BestwayAuthException, AwsIotAuthException) as err:

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -25,6 +25,21 @@
           "visitor_id": "Visitor ID (existing account, optional)",
           "qr_code": "QR Code (new account, optional)"
         }
+      },
+      "reauth_gizwits": {
+        "title": "Reauthenticate Bestway (V01)",
+        "description": "The Bestway server rejected your saved credentials for {username}. Enter your password to reconnect.",
+        "data": {
+          "password": "Password"
+        }
+      },
+      "reauth_aws_iot": {
+        "title": "Reauthenticate Bestway (V02)",
+        "description": "Automatic reconnection failed. Provide an existing visitor_id OR scan a new QR code to reconnect. Provide ONE option only.",
+        "data": {
+          "visitor_id": "Visitor ID (existing account, optional)",
+          "qr_code": "QR Code (new account, optional)"
+        }
       }
     },
     "error": {
@@ -41,6 +56,10 @@
       "no_devices_found": "No devices found. Please check your spa is powered on and connected.",
       "qr_code_required": "Either provide an existing visitor_id OR scan a QR code. One option is required.",
       "unknown": "Unknown error"
+    },
+    "abort": {
+      "reauth_successful": "Reauthentication was successful",
+      "reauth_entry_not_found": "The config entry being reauthenticated no longer exists"
     }
   },
   "options": {


### PR DESCRIPTION
Fixes a class of bugs where the integration silently stops working after a few days and requires removing and re-adding the device to recover. Root cause: cloud auth tokens can be invalidated server-side without warning, and the integration had no path to recover. Also widens HTTP timeouts, which were tight enough to cause spurious "Timeout fetching" failures and repeated Unavailable/Connected flapping even on a healthy connection.

Have tested for a number of days and now don't experience any issues 