### PR TITLE
Support new Bestway Connect share links (smart-spa-*-app) for 2025+ UltraFit devices

### DIFF
--- a/custom_components/bestway/__init__.py
+++ b/custom_components/bestway/__init__.py
@@ -17,6 +17,7 @@ from .bestway.websocket import GizwitsWebSocket
 from .const import (
     BACKEND_AWS_IOT,
     BACKEND_GIZWITS,
+    BACKEND_SMART_HOME,
     CONF_API_ROOT,
     CONF_API_ROOT_EU,
     CONF_PASSWORD,
@@ -52,6 +53,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if backend == BACKEND_AWS_IOT:
         # AWS IoT V02 backend
         return await _async_setup_aws_iot(hass, entry, session)
+    elif backend == BACKEND_SMART_HOME:
+        # Smart Home (Gizwits AEP) backend - newer Bestway Connect devices
+        return await _async_setup_smart_home(hass, entry, session)
     else:
         # Gizwits V01 backend (existing flow)
         return await _async_setup_gizwits(hass, entry, session)
@@ -249,6 +253,47 @@ async def _async_setup_aws_iot(
 
     # Store WebSockets list on coordinator
     coordinator.websockets = websockets
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    return True
+
+
+async def _async_setup_smart_home(
+    hass: HomeAssistant, entry: ConfigEntry, session: ClientSession
+) -> bool:
+    """Set up Smart Home (Gizwits AEP) backend for newer Bestway Connect devices."""
+    from .smart_home.api import SmartHomeApi, SmartHomeAuthException
+
+    phone_id = entry.data["phone_id"]
+    token = entry.data.get("token")
+    api_base = entry.data.get("api_base")
+
+    if not api_base:
+        from .smart_home.api import API_ENDPOINTS
+
+        region = entry.data.get("region", "EU")
+        api_base = API_ENDPOINTS.get(region, API_ENDPOINTS["EU"])
+
+    api = SmartHomeApi(session, phone_id, token, api_base)
+
+    # Refresh the session on startup. Anonymous tokens are long-lived but can
+    # be invalidated server-side, and re-authenticating is a single cheap POST
+    # that avoids leaving all entities unavailable until the next restart.
+    try:
+        token = await SmartHomeApi.authenticate(session, phone_id, api_base)
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "token": token}
+        )
+        api._token = token
+    except SmartHomeAuthException as ex:
+        _LOGGER.error("Smart Home authentication failed: %s", ex)
+        raise ConfigEntryAuthFailed from ex
+
+    coordinator = BestwayUpdateCoordinator(hass, entry, api)
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)

--- a/custom_components/bestway/bestway/model.py
+++ b/custom_components/bestway/bestway/model.py
@@ -8,7 +8,7 @@ from logging import getLogger
 
 from typing import Any
 
-from ..const import BACKEND_AWS_IOT, BACKEND_GIZWITS
+from ..const import BACKEND_AWS_IOT, BACKEND_GIZWITS, BACKEND_SMART_HOME
 
 _LOGGER = getLogger(__name__)
 
@@ -182,7 +182,13 @@ class BestwayDevice:
     @property
     def device_type(self) -> BestwayDeviceType:
         """Get the derived device type based on backend."""
-        if self.backend == BACKEND_AWS_IOT and self.product_series:
+        # The AWS IoT and Smart Home (AEP) backends both describe a device by
+        # its product series, and expose the same normalised shadow fields, so
+        # they share the same device-type mapping and entity behaviour.
+        if (
+            self.backend in (BACKEND_AWS_IOT, BACKEND_SMART_HOME)
+            and self.product_series
+        ):
             return BestwayDeviceType.from_aws_product_series(self.product_series)
         return BestwayDeviceType.from_api_product_name(self.product_name)
 

--- a/custom_components/bestway/config_flow.py
+++ b/custom_components/bestway/config_flow.py
@@ -28,6 +28,7 @@ from .bestway.api import (
 from .const import (
     BACKEND_AWS_IOT,
     BACKEND_GIZWITS,
+    BACKEND_SMART_HOME,
     BUBBLES_MODE_3WAY,
     BUBBLES_MODE_DEFAULT,
     BUBBLES_MODE_ONOFF,
@@ -238,6 +239,13 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
 
+        # Newer "Bestway Connect" devices (2025+ UltraFit) no longer produce an
+        # RW_Share_ code; their "Share device" QR is a smart-spa-*-app URL (or a
+        # bare share id). Route those to the Smart Home backend. The legacy
+        # RW_Share_ / visitor_id paths below are unchanged. (See issue #135.)
+        if qr_code and not qr_code.startswith("RW_Share_"):
+            return await self._async_step_smart_home_share(qr_code, region)
+
         try:
             from .aws_iot.api import AwsIotApi, API_ENDPOINTS
 
@@ -248,20 +256,6 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
 
             # Determine visitor_id
             if qr_code:
-                # Validate QR format
-                if not qr_code.startswith("RW_Share_"):
-                    errors["qr_code"] = "invalid_qr_format"
-                    return self.async_show_form(
-                        step_id="aws_iot_auth",
-                        data_schema=vol.Schema(
-                            {
-                                vol.Optional("qr_code"): str,
-                                vol.Optional("visitor_id"): str,
-                            }
-                        ),
-                        errors=errors,
-                    )
-
                 # Generate visitor_id for new account
                 visitor_id = AwsIotApi.generate_visitor_id()
 
@@ -364,6 +358,103 @@ class BestwayConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+    def _aws_iot_auth_form(
+        self, region: str, errors: dict[str, str]
+    ) -> ConfigFlowResult:
+        """Re-show the V02 auth form (shared by the AWS IoT and Smart Home paths)."""
+        return self.async_show_form(
+            step_id="aws_iot_auth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("region", default=region): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(value="EU", label="Europe"),
+                                selector.SelectOptionDict(
+                                    value="US", label="United States"
+                                ),
+                                selector.SelectOptionDict(value="CN", label="China"),
+                            ]
+                        )
+                    ),
+                    vol.Optional("visitor_id"): str,
+                    vol.Optional("qr_code"): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def _async_step_smart_home_share(
+        self, share_input: str, region: str
+    ) -> ConfigFlowResult:
+        """Set up the Smart Home (AEP) backend from a new-style share code.
+
+        Accepts the full share URL or a bare share id, creates an anonymous
+        session, redeems the invitation and verifies at least one device is
+        visible. The share id is never logged.
+        """
+        from .smart_home.api import (
+            API_ENDPOINTS,
+            SmartHomeApi,
+            SmartHomeAuthException,
+            SmartHomeException,
+            SmartHomeShareException,
+            parse_share_input,
+        )
+
+        errors: dict[str, str] = {}
+        try:
+            share_id, url_region = parse_share_input(share_input)
+        except SmartHomeShareException as err:
+            errors["qr_code"] = str(err)
+            return self._aws_iot_auth_form(region, errors)
+
+        # A region encoded in the share URL wins over the dropdown; otherwise
+        # fall back to the selected region (defaulting to EU if unsupported).
+        effective_region = url_region or region
+        api_base = API_ENDPOINTS.get(effective_region, API_ENDPOINTS["EU"])
+
+        session = async_get_clientsession(self.hass)
+        phone_id = SmartHomeApi.generate_phone_id()
+
+        try:
+            token = await SmartHomeApi.authenticate(
+                session, phone_id, api_base=api_base
+            )
+            await SmartHomeApi.accept_share(session, share_id, token, api_base=api_base)
+
+            api = SmartHomeApi(session, phone_id, token=token, api_base=api_base)
+            async with asyncio.timeout(15):
+                await api.refresh_bindings()
+        except SmartHomeShareException as err:
+            errors["qr_code"] = str(err)
+            return self._aws_iot_auth_form(region, errors)
+        except SmartHomeAuthException:
+            errors["base"] = "auth_failed"
+            return self._aws_iot_auth_form(region, errors)
+        except SmartHomeException:
+            errors["base"] = "cannot_connect"
+            return self._aws_iot_auth_form(region, errors)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Smart Home setup failed")
+            errors["base"] = "unknown"
+            return self._aws_iot_auth_form(region, errors)
+
+        if not api.devices:
+            errors["base"] = "no_devices_found"
+            return self._aws_iot_auth_form(region, errors)
+
+        return self.async_create_entry(
+            title=f"Bestway Spa (Connect - {effective_region})",
+            data={
+                "backend": BACKEND_SMART_HOME,
+                "phone_id": phone_id,
+                "token": token,
+                "region": effective_region,
+                "api_base": api_base,
+            },
         )
 
 

--- a/custom_components/bestway/const.py
+++ b/custom_components/bestway/const.py
@@ -16,6 +16,10 @@ GIZWITS_APP_ID = "98754e684ec045528b073876c34c7348"
 # Backend types
 BACKEND_GIZWITS = "gizwits"
 BACKEND_AWS_IOT = "aws_iot"
+# Newer "Bestway Connect" app backed by the Gizwits AEP super-app gateway
+# (smart-spa-*-app.bestwaycorp.com). Used by 2025+ UltraFit models whose
+# "Share device" QR now yields a URL instead of an RW_Share_ code (issue #135).
+BACKEND_SMART_HOME = "smart_home"
 
 # Bubble UI mode (Airjet V02). Some V02 hardware (e.g. T53NN8 batches)
 # only has on/off bubbles physically, while others support 3 levels.

--- a/custom_components/bestway/coordinator.py
+++ b/custom_components/bestway/coordinator.py
@@ -15,6 +15,7 @@ from .aws_iot.websocket import AwsIotWebSocket
 from .bestway.api import BestwayApi, BestwayApiResults
 from .bestway.model import BestwayDeviceStatus
 from .bestway.websocket import GizwitsWebSocket
+from .smart_home.api import SmartHomeApi
 
 _LOGGER = getLogger(__name__)
 
@@ -26,7 +27,7 @@ class BestwayUpdateCoordinator(DataUpdateCoordinator[BestwayApiResults]):
         self,
         hass: HomeAssistant,
         config_entry: ConfigEntry,
-        api: BestwayApi | AwsIotApi,
+        api: BestwayApi | AwsIotApi | SmartHomeApi,
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -27,6 +27,7 @@ from .const import (
     Icon,
 )
 from .entity import BestwayEntity
+from .smart_home.api import SmartHomeApi
 
 _BUBBLES_OPTIONS = {
     BubblesLevel.OFF: "OFF",
@@ -39,7 +40,9 @@ _BUBBLES_OPTIONS = {
 class BubblesSelectEntityDescription(SelectEntityDescription):
     """Describes bubbles selection."""
 
-    set_fn: Callable[[BestwayApi | AwsIotApi, str, BubblesLevel], Awaitable[None]]
+    set_fn: Callable[
+        [BestwayApi | AwsIotApi | SmartHomeApi, str, BubblesLevel], Awaitable[None]
+    ]
     get_fn: Callable[[int], BubblesLevel]
 
 

--- a/custom_components/bestway/smart_home/api.py
+++ b/custom_components/bestway/smart_home/api.py
@@ -1,0 +1,460 @@
+"""Smart Home (Gizwits AEP) API client for newer "Bestway Connect" devices.
+
+Backend: Gizwits AEP super-app gateway (smart-spa-*-app.bestwaycorp.com)
+App: Bestway Connect (2025+), user-agent ``gizwitssuperapprn/*``
+Devices: 2025+ UltraFit models (Airjet/Hydrojet V02) whose "Share device" QR
+now yields a URL instead of an ``RW_Share_`` code (issue #135).
+
+This client mirrors the ``AwsIotApi`` interface so it drops straight into the
+existing coordinator and entity infrastructure. The device shadow exposes the
+same field names the AWS IoT backend already handles, so state normalisation
+is shared via :meth:`AwsIotApi.normalize_aws_state`.
+
+Notes on the protocol (established by observing the official app):
+
+* Auth is an anonymous session token; no username/password is required.
+* Requests authenticate with ``X-Gizwits-Application-Id`` plus the session
+  token in ``Authorization`` (and ``X-Gizwits-User-Token``). The app also
+  sends an ``X-Gizwits-Ca-Signature`` (HmacSHA256) header, but the gateway
+  does not enforce it on these endpoints, so we do not compute one.
+* Every response is HTTP 200 with a business ``code`` in the JSON body
+  (``"200"`` on success); errors are reported there, not via HTTP status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from logging import getLogger
+import re
+from time import time
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+import uuid
+
+from aiohttp import ClientError, ClientSession
+
+from ..bestway.model import BestwayDevice, BestwayDeviceStatus, BubblesLevel
+from ..const import BACKEND_SMART_HOME
+
+_LOGGER = getLogger(__name__)
+
+# Gizwits AEP application id for the Bestway Connect app. Shared across
+# regions (matches the AWS IoT backend, which also uses one id for EU/US).
+APP_ID = "39ef26ff404a4cb1b5652f336d4bc045"
+TIMEOUT = 15
+
+# Regional gateway endpoints. The share URL host encodes the region as
+# ``smart-spa-<region>-app``; the config flow region select is the fallback
+# when only a bare share id is supplied.
+API_ENDPOINTS = {
+    "EU": "https://smart-spa-eu-app.bestwaycorp.com",
+    "US": "https://smart-spa-us-app.bestwaycorp.com",
+}
+DEFAULT_API_BASE = API_ENDPOINTS["EU"]
+
+# Host pattern for the new share URLs, e.g.
+# https://smart-spa-eu-app.bestwaycorp.com/app/<appid>/shareDevice/index.html?shareId=<id>
+_SHARE_HOST_RE = re.compile(
+    r"^smart-spa-(?P<region>[a-z]{2})-app\.bestwaycorp\.com$", re.IGNORECASE
+)
+# A share id is a hex token. Kept deliberately broad (16-64 hex chars) so minor
+# backend changes to the id length don't reject an otherwise valid invitation.
+_SHARE_ID_RE = re.compile(r"^[0-9a-fA-F]{16,64}$")
+
+# Map known product keys to a product series so the existing device-type
+# machinery (and therefore the right entities) applies. Unknown keys fall back
+# to a generic Airjet V02, whose normalised fields cover the common controls.
+_PRODUCT_KEY_SERIES = {
+    "FTEW0E": "ULTRAFIT_AIRJET",
+}
+
+
+class SmartHomeException(Exception):
+    """Base exception for Smart Home (AEP) API operations."""
+
+
+class SmartHomeAuthException(SmartHomeException):
+    """Authentication/session error."""
+
+
+class SmartHomeShareException(SmartHomeException):
+    """A device share invitation could not be redeemed."""
+
+
+def parse_share_input(raw: str) -> tuple[str, str | None]:
+    """Extract the share id (and region, if present) from user input.
+
+    Accepts either the full share URL from the app's "Share device" QR code,
+    or a bare share id. Returns ``(share_id, region_or_none)``.
+
+    Raises:
+        SmartHomeShareException: If no valid share id can be found. The message
+            is safe to surface; it never includes the share id itself.
+    """
+    value = (raw or "").strip()
+    if not value:
+        raise SmartHomeShareException("missing_share_id")
+
+    # Bare share id (not a URL).
+    if "://" not in value and "/" not in value:
+        if _SHARE_ID_RE.match(value):
+            return value, None
+        raise SmartHomeShareException("invalid_share_id")
+
+    parsed = urlparse(value)
+    host_match = _SHARE_HOST_RE.match(parsed.hostname or "")
+    region = host_match.group("region").upper() if host_match else None
+
+    share_id = parse_qs(parsed.query).get("shareId", [""])[0].strip()
+    if not share_id:
+        raise SmartHomeShareException("missing_share_id")
+    if not _SHARE_ID_RE.match(share_id):
+        raise SmartHomeShareException("invalid_share_id")
+
+    return share_id, (region if region in API_ENDPOINTS else None)
+
+
+class SmartHomeApi:
+    """Smart Home (AEP) API client matching the AwsIotApi interface."""
+
+    def __init__(
+        self,
+        session: ClientSession,
+        phone_id: str,
+        token: str | None = None,
+        api_base: str = DEFAULT_API_BASE,
+    ) -> None:
+        """Initialise the client.
+
+        Args:
+            session: aiohttp ClientSession for HTTP requests.
+            phone_id: Stable per-install id used for the anonymous session.
+            token: Session token (optional; re-authenticate if None).
+            api_base: Regional gateway base URL.
+        """
+        self._session = session
+        self._phone_id = phone_id
+        self._token = token
+        self._api_base = api_base
+
+        # Matches the AwsIotApi/BestwayApi interface consumed by the coordinator.
+        self.devices: dict[str, BestwayDevice] = {}
+        self._state_cache: dict[str, BestwayDeviceStatus] = {}
+
+    @staticmethod
+    def generate_phone_id() -> str:
+        """Generate a stable per-install id for the anonymous session."""
+        return str(uuid.uuid4())
+
+    # ---- HTTP helpers -----------------------------------------------------
+
+    def _headers(self, authed: bool = True) -> dict[str, str]:
+        """Build request headers.
+
+        The gateway does not enforce the HmacSHA256 signature the app sends,
+        so only the application id and (when authed) the session token are
+        required.
+        """
+        headers = {
+            "X-Gizwits-Application-Id": APP_ID,
+            "Content-Type": "application/json",
+            "Accept": "application/json; charset=utf-8",
+            "version": "1.0",
+            "User-Agent": "gizwitssuperapprn/131600000",
+        }
+        if authed:
+            if not self._token:
+                raise SmartHomeAuthException("No session token available")
+            headers["Authorization"] = self._token
+            headers["X-Gizwits-User-Token"] = self._token
+        return headers
+
+    @staticmethod
+    def _payload(data: Any) -> dict[str, Any]:
+        """Wrap a data object in the gateway's standard request envelope."""
+        return {"appKey": APP_ID, "data": data, "version": "1.0"}
+
+    @staticmethod
+    def _check(body: dict[str, Any]) -> dict[str, Any]:
+        """Validate the business ``code`` inside an HTTP 200 response.
+
+        The gateway returns errors in the body, not the HTTP status, so a plain
+        ``raise_for_status`` is not enough (see issue #135).
+        """
+        code = str(body.get("code"))
+        if body.get("error") or code != "200":
+            # Map the auth/session codes to an auth exception so Home Assistant
+            # can trigger re-authentication rather than a generic failure.
+            if code in ("505", "401", "403"):
+                raise SmartHomeAuthException(f"Session rejected (code {code})")
+            raise SmartHomeException(f"API error (code {code})")
+        return body
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        authed: bool = True,
+    ) -> dict[str, Any]:
+        """Perform a request and return the validated JSON body."""
+        url = f"{self._api_base}{path}"
+        # Only attach a JSON body when there is one; passing json=None would
+        # send the literal "null" instead of an empty body, which the share
+        # redeem endpoint (empty body) rejects.
+        kwargs: dict[str, Any] = {
+            "headers": self._headers(authed=authed),
+            "ssl": False,
+        }
+        if json_body is not None:
+            kwargs["json"] = json_body
+        try:
+            async with asyncio.timeout(TIMEOUT):
+                async with self._session.request(method, url, **kwargs) as response:
+                    body = await response.json(content_type=None)
+        except (ClientError, TimeoutError) as err:
+            raise SmartHomeException(f"Cannot reach Bestway API: {err}") from err
+        if not isinstance(body, dict):
+            raise SmartHomeException("Unexpected API response")
+        return self._check(body)
+
+    # ---- Authentication ---------------------------------------------------
+
+    @staticmethod
+    async def authenticate(
+        session: ClientSession,
+        phone_id: str,
+        api_base: str = DEFAULT_API_BASE,
+    ) -> str:
+        """Create/refresh an anonymous session and return its token."""
+        payload = {
+            "appKey": APP_ID,
+            "data": {"phoneId": phone_id, "homeName": "Home Assistant", "lang": "en"},
+            "version": "1.0",
+        }
+        client = SmartHomeApi(session, phone_id, api_base=api_base)
+        body = await client._request(
+            "POST", "/app/smart_home/login/anonymous", json_body=payload, authed=False
+        )
+        token = (body.get("data") or {}).get("userToken")
+        if not token:
+            raise SmartHomeAuthException("No token in login response")
+        return str(token)
+
+    # ---- Device sharing ---------------------------------------------------
+
+    @staticmethod
+    async def accept_share(
+        session: ClientSession,
+        share_id: str,
+        token: str,
+        api_base: str = DEFAULT_API_BASE,
+    ) -> None:
+        """Redeem a device-share invitation for the current session.
+
+        The share id travels in the URL path with an empty request body.
+        """
+        client = SmartHomeApi(session, "", token=token, api_base=api_base)
+        try:
+            await client._request(
+                "POST", f"/app/smartHome/homes/singleDeviceShareV2/{share_id}"
+            )
+        except SmartHomeException as err:
+            # Re-raise with a translation key the config flow can show. The
+            # share id is never included in the message.
+            code = _extract_code(err)
+            if code == "2000066":
+                # "You have already shared this device" — the owner scanned
+                # their own invitation. Treat as already-linked, not fatal.
+                raise SmartHomeShareException("share_already_used") from err
+            if code in ("4000002", "4000001"):
+                raise SmartHomeShareException("invalid_share_id") from err
+            if code in ("2000001", "2000021"):
+                raise SmartHomeShareException("device_not_found") from err
+            raise SmartHomeShareException("share_failed") from err
+
+    # ---- Discovery + state ------------------------------------------------
+
+    async def refresh_bindings(self) -> None:
+        """Discover devices for the current session (cached after first run)."""
+        if self.devices:
+            _LOGGER.debug("Using cached device list (%d devices)", len(self.devices))
+            return
+
+        body = await self._request("GET", "/app/smartHome/v2/users/devices")
+        raw_devices = body.get("data") or []
+        _LOGGER.debug("Discovered %d device(s)", len(raw_devices))
+
+        devices: dict[str, BestwayDevice] = {}
+        for dev in raw_devices:
+            mac = dev.get("mac")
+            product_key = (dev.get("productKey") or "").strip()
+            if not mac or not product_key:
+                continue
+            series = _PRODUCT_KEY_SERIES.get(product_key, "AIRJET")
+            devices[mac] = BestwayDevice(
+                protocol_version=2,
+                device_id=mac,
+                product_name=series,
+                alias=dev.get("name") or mac,
+                mcu_soft_version="unknown",
+                mcu_hard_version="unknown",
+                wifi_soft_version="unknown",
+                wifi_hard_version="unknown",
+                is_online=dev.get("onlineStatus") == 1,
+                backend=BACKEND_SMART_HOME,
+                product_id=product_key,
+                product_series=series,
+            )
+        self.devices = devices
+
+    async def fetch_data(self) -> Any:  # Returns BestwayApiResults
+        """Fetch and normalise the latest state for all devices."""
+        from ..aws_iot.api import AwsIotApi
+        from ..bestway.api import BestwayApiResults
+
+        for device_id, device in self.devices.items():
+            try:
+                body = await self._request(
+                    "GET",
+                    f"/app/device/shadow/{device.product_id}/{device_id}",
+                )
+                device_state = body.get("data") or {}
+                mapped = AwsIotApi.normalize_aws_state(device_state)
+                self._state_cache[device_id] = BestwayDeviceStatus(
+                    timestamp=int(time()), attrs=mapped
+                )
+            except SmartHomeAuthException:
+                # Let the coordinator surface auth failures for re-auth.
+                raise
+            except SmartHomeException as err:
+                _LOGGER.warning("Failed to fetch state for a device: %s", err)
+                if device_id not in self._state_cache:
+                    self._state_cache[device_id] = BestwayDeviceStatus(
+                        timestamp=int(time()), attrs={}
+                    )
+
+        return BestwayApiResults(devices=self._state_cache)
+
+    async def set_device_state(
+        self, device_id: str, state_updates: dict[str, Any]
+    ) -> bool:
+        """Send a control command using AWS-style field names (plaintext JSON)."""
+        import json as json_module
+
+        updates: dict[str, Any] = {}
+        for key, value in state_updates.items():
+            if isinstance(value, bool):
+                value = 1 if value else 0
+            elif hasattr(value, "value"):  # IntEnum
+                value = int(value.value)
+            elif not isinstance(value, int):
+                value = int(value)
+            updates[key] = value
+
+        if not updates:
+            return False
+
+        device = self.devices[device_id]
+        # The gateway expects `data` as a JSON *string* of the desired fields.
+        payload = self._payload(json_module.dumps(updates, separators=(",", ":")))
+        _LOGGER.debug("Smart Home command: fields=%s", list(updates.keys()))
+        body = await self._request(
+            "POST",
+            f"/app/device/control/{device.product_id}/{device_id}",
+            json_body=payload,
+        )
+        return bool(body.get("data"))
+
+    # ---- Convenience methods (match AwsIotApi interface) ------------------
+    #
+    # These UltraFit devices report/accept a simple wave_state on/off (0/1)
+    # rather than the 0/40/100 the AWS IoT backend uses, so the bubble helpers
+    # are overridden accordingly. All other helpers reuse AWS field names.
+
+    async def airjet_spa_set_power(self, device_id: str, state: bool) -> None:
+        """Set power state."""
+        await self.set_device_state(device_id, {"power_state": 1 if state else 0})
+
+    async def airjet_spa_set_filter(self, device_id: str, state: bool) -> None:
+        """Set filter state."""
+        await self.set_device_state(device_id, {"filter_state": 1 if state else 0})
+
+    async def airjet_spa_set_bubbles(self, device_id: str, state: bool) -> None:
+        """Set bubbles on/off."""
+        await self.set_device_state(device_id, {"wave_state": 1 if state else 0})
+
+    async def airjet_spa_set_heat(self, device_id: str, heat: bool) -> None:
+        """Set heater state."""
+        await self.set_device_state(device_id, {"heater_state": 1 if heat else 0})
+
+    async def airjet_spa_set_locked(self, device_id: str, state: bool) -> None:
+        """Set panel lock state."""
+        await self.set_device_state(device_id, {"locked": 1 if state else 0})
+
+    async def airjet_spa_set_target_temp(
+        self, device_id: str, temperature: int
+    ) -> None:
+        """Set target temperature."""
+        await self.set_device_state(device_id, {"temperature_setting": temperature})
+
+    async def hydrojet_spa_set_power(self, device_id: str, state: bool) -> None:
+        """Set power state."""
+        await self.set_device_state(device_id, {"power_state": 1 if state else 0})
+
+    async def hydrojet_spa_set_filter(self, device_id: str, filter_state: int) -> None:
+        """Set filter state (V02 uses 1 for ON, not 2)."""
+        value = filter_state.value if hasattr(filter_state, "value") else filter_state
+        if value == 2:
+            value = 1
+        await self.set_device_state(device_id, {"filter_state": value})
+
+    async def hydrojet_spa_set_jets(self, device_id: str, state: bool) -> None:
+        """Set jets state."""
+        await self.set_device_state(device_id, {"hydrojet_state": 1 if state else 0})
+
+    async def hydrojet_spa_set_heat(self, device_id: str, heat_state: int) -> None:
+        """Set heater state (climate sends 0/3; device expects 0/1)."""
+        value = 1 if heat_state == 3 else 0
+        await self.set_device_state(device_id, {"heater_state": value})
+
+    async def hydrojet_spa_set_target_temp(
+        self, device_id: str, temperature: int
+    ) -> None:
+        """Set target temperature."""
+        await self.set_device_state(device_id, {"temperature_setting": temperature})
+
+    async def airjet_v01_spa_set_bubbles(
+        self, device_id: str, level: BubblesLevel
+    ) -> None:
+        """Set bubbles from a 3-way level.
+
+        UltraFit hardware observed so far is on/off only, so any non-OFF level
+        maps to on. The precise level behaviour is verified against real
+        hardware; users with on/off hardware can pick "On / Off only" in the
+        integration options for a plain switch.
+        """
+        await self.set_device_state(
+            device_id, {"wave_state": 0 if level == BubblesLevel.OFF else 1}
+        )
+
+    async def hydrojet_spa_set_bubbles(
+        self, device_id: str, level: BubblesLevel
+    ) -> None:
+        """Set bubbles from a 3-way level (see airjet_v01_spa_set_bubbles)."""
+        await self.airjet_v01_spa_set_bubbles(device_id, level)
+
+    async def pool_filter_set_power(self, device_id: str, power: bool) -> None:
+        """Not supported on these devices."""
+        raise NotImplementedError("Pool filter not supported on Smart Home devices")
+
+    async def pool_filter_set_time(self, device_id: str, hours: int) -> None:
+        """Not supported on these devices."""
+        raise NotImplementedError("Pool filter not supported on Smart Home devices")
+
+
+def _extract_code(err: Exception) -> str | None:
+    """Pull the numeric business code out of a SmartHomeException message."""
+    match = re.search(r"code (\d+)", str(err))
+    return match.group(1) if match else None

--- a/custom_components/bestway/switch.py
+++ b/custom_components/bestway/switch.py
@@ -25,6 +25,7 @@ from .const import (
     Icon,
 )
 from .entity import BestwayEntity
+from .smart_home.api import SmartHomeApi
 
 # Maximum time an optimistic value is trusted before the entity falls back
 # to whatever the cloud last reported. Long enough to ride out a normal
@@ -38,8 +39,8 @@ class BestwaySwitchEntityDescription(SwitchEntityDescription):
     """Entity description for bestway spa switches."""
 
     value_fn: Callable[[BestwayDeviceStatus], bool]
-    turn_on_fn: Callable[[BestwayApi | AwsIotApi, str], Awaitable[None]]
-    turn_off_fn: Callable[[BestwayApi | AwsIotApi, str], Awaitable[None]]
+    turn_on_fn: Callable[[BestwayApi | AwsIotApi | SmartHomeApi, str], Awaitable[None]]
+    turn_off_fn: Callable[[BestwayApi | AwsIotApi | SmartHomeApi, str], Awaitable[None]]
 
 
 _AIRJET_SPA_POWER_SWITCH = BestwaySwitchEntityDescription(

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -19,11 +19,11 @@
       },
       "aws_iot_auth": {
         "title": "Bestway V02 Login (AWS IoT)",
-        "description": "Choose setup method: Use an existing visitor_id OR scan a QR code to create a new account. Provide ONE option only.",
+        "description": "Paste the code or link from the app's Share device screen (both the older RW_Share_ code and the newer smart-spa share link are accepted), OR enter an existing visitor_id. Provide ONE option only.",
         "data": {
           "region": "Region",
           "visitor_id": "Visitor ID (existing account, optional)",
-          "qr_code": "QR Code (new account, optional)"
+          "qr_code": "Share code or link (optional)"
         }
       }
     },
@@ -40,6 +40,11 @@
       "binding_failed": "QR code binding failed. The code may be expired or already used. Generate a fresh QR code from your spa.",
       "no_devices_found": "No devices found. Please check your spa is powered on and connected.",
       "qr_code_required": "Either provide an existing visitor_id OR scan a QR code. One option is required.",
+      "missing_share_id": "No share id found in that link. Copy the full 'Share device' link (or the share id) from the Bestway Connect app.",
+      "invalid_share_id": "That share code doesn't look valid. Copy the full 'Share device' link from the Bestway Connect app and try again.",
+      "share_already_used": "This share is already linked to this account, or you scanned your own device's invitation. Generate a fresh share link and try again.",
+      "device_not_found": "The shared device could not be found. Make sure the spa is powered on and the share link is fresh, then try again.",
+      "share_failed": "Could not redeem the share link. It may have expired or already been used. Generate a fresh link from the Bestway Connect app.",
       "unknown": "Unknown error"
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -178,7 +178,11 @@ async def test_aws_iot_auth_requires_qr_or_visitor(hass):
 
 
 async def test_aws_iot_qr_validation(hass):
-    """Test QR code format validation."""
+    """Test that unrecognised share input is rejected with a clear error.
+
+    A code that is neither a legacy RW_Share_ token nor a valid new-style
+    share link/id is routed to the Smart Home path and rejected there.
+    """
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -194,9 +198,132 @@ async def test_aws_iot_qr_validation(hass):
         user_input={"qr_code": "INVALID_QR_123"},
     )
 
-    # Should show QR format error
+    # Should show a clear share-id error (no network call is made)
     assert result["type"] == FlowResultType.FORM
-    assert result["errors"]["qr_code"] == "invalid_qr_format"
+    assert result["errors"]["qr_code"] == "invalid_share_id"
+
+
+async def test_smart_home_share_url_creates_entry(hass):
+    """A new-style share URL creates a Smart Home backend entry."""
+    from custom_components.bestway.bestway.model import BestwayDevice
+    from custom_components.bestway.const import BACKEND_SMART_HOME
+
+    share_url = (
+        "https://smart-spa-eu-app.bestwaycorp.com/app/appid/shareDevice/"
+        "index.html?shareId=0123456789abcdef0123456789abcdef"
+    )
+
+    async def fake_refresh(self):
+        self.devices = {
+            "aabbccddeeff": BestwayDevice(
+                protocol_version=2,
+                device_id="aabbccddeeff",
+                product_name="ULTRAFIT_AIRJET",
+                alias="Toronto",
+                mcu_soft_version="x",
+                mcu_hard_version="x",
+                wifi_soft_version="x",
+                wifi_hard_version="x",
+                is_online=True,
+                backend=BACKEND_SMART_HOME,
+                product_id="FTEW0E",
+                product_series="ULTRAFIT_AIRJET",
+            )
+        }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "aws_iot"}
+    )
+
+    with (
+        patch(
+            "custom_components.bestway.smart_home.api.SmartHomeApi.authenticate",
+            return_value="test-token",
+        ),
+        patch(
+            "custom_components.bestway.smart_home.api.SmartHomeApi.accept_share",
+        ),
+        patch(
+            "custom_components.bestway.smart_home.api.SmartHomeApi.refresh_bindings",
+            fake_refresh,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={"region": "EU", "qr_code": share_url}
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"]["backend"] == BACKEND_SMART_HOME
+    assert result["data"]["region"] == "EU"
+    # The share id must never be persisted in the config entry.
+    assert "0123456789abcdef" not in str(result["data"])
+
+
+async def test_smart_home_url_without_share_id(hass):
+    """A share URL missing the shareId shows a clear error, makes no request."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "aws_iot"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            "region": "EU",
+            "qr_code": (
+                "https://smart-spa-eu-app.bestwaycorp.com/app/x/shareDevice/index.html"
+            ),
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["qr_code"] == "missing_share_id"
+
+
+async def test_rw_share_still_uses_aws_backend(hass):
+    """A legacy RW_Share_ code is still handled by the AWS IoT backend."""
+    from custom_components.bestway.const import BACKEND_AWS_IOT
+
+    async def fake_refresh(self):
+        self.devices = {}  # no devices -> flow stops with no_devices_found
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"backend": "aws_iot"}
+    )
+
+    with (
+        patch(
+            "custom_components.bestway.aws_iot.api.AwsIotApi.authenticate",
+            return_value="tok",
+        ),
+        patch(
+            "custom_components.bestway.aws_iot.api.AwsIotApi.bind_qr_code",
+            return_value={"device_id": "x"},
+        ),
+        patch(
+            "custom_components.bestway.aws_iot.api.AwsIotApi.refresh_bindings",
+            fake_refresh,
+        ),
+        patch(
+            "custom_components.bestway.smart_home.api.SmartHomeApi.authenticate",
+            side_effect=AssertionError("Smart Home path must not run for RW_Share_"),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"region": "EU", "qr_code": "RW_Share_deadbeef"},
+        )
+
+    # Reaches the AWS IoT device-discovery stage (no devices in this test).
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"]["base"] == "no_devices_found"
+    _ = BACKEND_AWS_IOT
 
 
 async def test_backend_selection_shows_both_options(hass):

--- a/tests/test_smart_home_api.py
+++ b/tests/test_smart_home_api.py
@@ -1,0 +1,308 @@
+"""Tests for the Smart Home (Gizwits AEP) API client.
+
+All external Bestway API calls are mocked. Every share id, token and MAC used
+here is fictitious.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.bestway.const import BACKEND_SMART_HOME
+from custom_components.bestway.smart_home.api import (
+    SmartHomeApi,
+    SmartHomeAuthException,
+    SmartHomeException,
+    SmartHomeShareException,
+    parse_share_input,
+)
+
+# Fictitious values — not real credentials.
+FAKE_SHARE_ID = "0123456789abcdef0123456789abcdef"
+FAKE_TOKEN = "test-session-token"
+FAKE_MAC = "aabbccddeeff"
+FAKE_PRODUCT_KEY = "FTEW0E"
+EU_URL = (
+    "https://smart-spa-eu-app.bestwaycorp.com/app/"
+    "0000000000000000000000000000abcd/shareDevice/index.html"
+    f"?shareId={FAKE_SHARE_ID}"
+)
+US_URL = (
+    "https://smart-spa-us-app.bestwaycorp.com/app/x/shareDevice/index.html"
+    f"?shareId={FAKE_SHARE_ID}"
+)
+
+
+def _cm(json_data: dict, status: int = 200):
+    """Build a mocked aiohttp response usable as an async context manager."""
+    response = AsyncMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+    return response
+
+
+def _session(*responses):
+    """Mock ClientSession whose .request() yields the given responses in order."""
+    session = MagicMock()
+    session.request = MagicMock(side_effect=list(responses))
+    return session
+
+
+def _ok(data):
+    return {"code": "200", "message": "ok", "data": data, "error": False}
+
+
+# --- parse_share_input -------------------------------------------------------
+
+
+def test_parse_full_eu_url():
+    """A full EU share URL yields the share id and EU region."""
+    share_id, region = parse_share_input(EU_URL)
+    assert share_id == FAKE_SHARE_ID
+    assert region == "EU"
+
+
+def test_parse_full_us_url():
+    """A US share URL yields the US region."""
+    share_id, region = parse_share_input(US_URL)
+    assert share_id == FAKE_SHARE_ID
+    assert region == "US"
+
+
+def test_parse_bare_share_id():
+    """A bare hex share id is accepted with no region."""
+    share_id, region = parse_share_input(FAKE_SHARE_ID)
+    assert share_id == FAKE_SHARE_ID
+    assert region is None
+
+
+def test_parse_url_without_share_id():
+    """A share URL missing the shareId parameter is rejected clearly."""
+    url = "https://smart-spa-eu-app.bestwaycorp.com/app/x/shareDevice/index.html"
+    with pytest.raises(SmartHomeShareException) as err:
+        parse_share_input(url)
+    assert str(err.value) == "missing_share_id"
+
+
+def test_parse_empty_input():
+    """Empty input is rejected as a missing share id."""
+    with pytest.raises(SmartHomeShareException) as err:
+        parse_share_input("   ")
+    assert str(err.value) == "missing_share_id"
+
+
+def test_parse_invalid_garbage():
+    """Non-URL, non-hex input is rejected as an invalid share id."""
+    with pytest.raises(SmartHomeShareException) as err:
+        parse_share_input("INVALID_QR_123")
+    assert str(err.value) == "invalid_share_id"
+
+
+def test_parse_unexpected_share_id_format():
+    """A shareId that isn't hex is rejected as invalid, not accepted blindly."""
+    url = (
+        "https://smart-spa-eu-app.bestwaycorp.com/app/x/shareDevice/index.html"
+        "?shareId=not-a-valid-id"
+    )
+    with pytest.raises(SmartHomeShareException) as err:
+        parse_share_input(url)
+    assert str(err.value) == "invalid_share_id"
+
+
+def test_parse_unknown_host_still_uses_share_id():
+    """An unrecognised host falls back to no region but keeps a valid share id."""
+    url = f"https://example.com/whatever?shareId={FAKE_SHARE_ID}"
+    share_id, region = parse_share_input(url)
+    assert share_id == FAKE_SHARE_ID
+    assert region is None
+
+
+# --- authenticate ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_authenticate_returns_token():
+    """A successful anonymous login returns the session token."""
+    session = _session(_cm(_ok({"userToken": FAKE_TOKEN, "refreshToken": "r"})))
+    token = await SmartHomeApi.authenticate(session, "phone-id")
+    assert token == FAKE_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_authenticate_missing_token_raises():
+    """A login response without a token raises an auth exception."""
+    session = _session(_cm(_ok({})))
+    with pytest.raises(SmartHomeAuthException):
+        await SmartHomeApi.authenticate(session, "phone-id")
+
+
+@pytest.mark.asyncio
+async def test_authenticate_error_code_raises():
+    """A non-200 business code raises."""
+    session = _session(_cm({"code": "500", "error": True, "data": None}))
+    with pytest.raises(SmartHomeException):
+        await SmartHomeApi.authenticate(session, "phone-id")
+
+
+# --- accept_share ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_share_success():
+    """A 200 response redeems the share without error."""
+    session = _session(_cm(_ok(FAKE_SHARE_ID)))
+    await SmartHomeApi.accept_share(session, FAKE_SHARE_ID, FAKE_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_accept_share_already_used():
+    """Code 2000066 maps to a clear 'already used' error."""
+    session = _session(
+        _cm({"code": "2000066", "message": "already shared", "error": True})
+    )
+    with pytest.raises(SmartHomeShareException) as err:
+        await SmartHomeApi.accept_share(session, FAKE_SHARE_ID, FAKE_TOKEN)
+    assert str(err.value) == "share_already_used"
+
+
+@pytest.mark.asyncio
+async def test_accept_share_invalid_id():
+    """Code 4000002 maps to an invalid-share-id error."""
+    session = _session(_cm({"code": "4000002", "error": True}))
+    with pytest.raises(SmartHomeShareException) as err:
+        await SmartHomeApi.accept_share(session, FAKE_SHARE_ID, FAKE_TOKEN)
+    assert str(err.value) == "invalid_share_id"
+
+
+@pytest.mark.asyncio
+async def test_accept_share_device_not_found():
+    """Code 2000001 maps to a device-not-found error."""
+    session = _session(_cm({"code": "2000001", "error": True}))
+    with pytest.raises(SmartHomeShareException) as err:
+        await SmartHomeApi.accept_share(session, FAKE_SHARE_ID, FAKE_TOKEN)
+    assert str(err.value) == "device_not_found"
+
+
+# --- refresh_bindings + fetch_data ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_bindings_builds_devices():
+    """Device discovery maps the API list into BestwayDevice objects."""
+    device_list = [
+        {
+            "mac": FAKE_MAC,
+            "productKey": FAKE_PRODUCT_KEY,
+            "name": "Toronto",
+            "onlineStatus": 1,
+        }
+    ]
+    api = SmartHomeApi(_session(_cm(_ok(device_list))), "phone-id", token=FAKE_TOKEN)
+    await api.refresh_bindings()
+
+    assert FAKE_MAC in api.devices
+    device = api.devices[FAKE_MAC]
+    assert device.backend == BACKEND_SMART_HOME
+    assert device.product_id == FAKE_PRODUCT_KEY
+    assert device.product_series == "ULTRAFIT_AIRJET"
+    assert device.alias == "Toronto"
+    assert device.is_online is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_bindings_skips_incomplete_entries():
+    """Entries missing a mac or productKey are skipped, not crashed on."""
+    device_list = [{"productKey": FAKE_PRODUCT_KEY}, {"mac": FAKE_MAC}]
+    api = SmartHomeApi(_session(_cm(_ok(device_list))), "phone-id", token=FAKE_TOKEN)
+    await api.refresh_bindings()
+    assert api.devices == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_normalizes_shadow():
+    """Shadow fields are normalised into the shared V01 attribute names."""
+    shadow = {
+        "power_state": 1,
+        "water_temperature": 35,
+        "temperature_setting": 37,
+        "wave_state": 0,
+        "filter_state": 2,
+        "heater_state": 4,
+    }
+    device_list = [
+        {
+            "mac": FAKE_MAC,
+            "productKey": FAKE_PRODUCT_KEY,
+            "name": "x",
+            "onlineStatus": 1,
+        }
+    ]
+    api = SmartHomeApi(
+        _session(_cm(_ok(device_list)), _cm(_ok(shadow))),
+        "phone-id",
+        token=FAKE_TOKEN,
+    )
+    await api.refresh_bindings()
+    results = await api.fetch_data()
+
+    attrs = results.devices[FAKE_MAC].attrs
+    assert attrs["power"] is True
+    assert attrs["Tnow"] == 35
+    assert attrs["Tset"] == 37
+
+
+# --- set_device_state --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_device_state_sends_plaintext_command():
+    """Control commands post plaintext JSON field names to the control path."""
+    api = SmartHomeApi(MagicMock(), "phone-id", token=FAKE_TOKEN)
+    api.devices = await _one_device(api)
+    api._request = AsyncMock(return_value=_ok(True))
+
+    await api.airjet_spa_set_bubbles(FAKE_MAC, True)
+
+    method, path = api._request.call_args.args[0], api._request.call_args.args[1]
+    body = api._request.call_args.kwargs["json_body"]
+    assert method == "POST"
+    assert path == f"/app/device/control/{FAKE_PRODUCT_KEY}/{FAKE_MAC}"
+    # `data` is a JSON *string* of the desired fields.
+    assert body["data"] == '{"wave_state":1}'
+
+
+@pytest.mark.asyncio
+async def test_set_target_temp_command():
+    """Target temperature is sent as an integer field."""
+    api = SmartHomeApi(MagicMock(), "phone-id", token=FAKE_TOKEN)
+    api.devices = await _one_device(api)
+    api._request = AsyncMock(return_value=_ok(True))
+
+    await api.airjet_spa_set_target_temp(FAKE_MAC, 38)
+    assert api._request.call_args.kwargs["json_body"]["data"] == (
+        '{"temperature_setting":38}'
+    )
+
+
+async def _one_device(api: SmartHomeApi):
+    """Helper: a single discovered device dict for control tests."""
+    from custom_components.bestway.bestway.model import BestwayDevice
+
+    return {
+        FAKE_MAC: BestwayDevice(
+            protocol_version=2,
+            device_id=FAKE_MAC,
+            product_name="ULTRAFIT_AIRJET",
+            alias="Toronto",
+            mcu_soft_version="x",
+            mcu_hard_version="x",
+            wifi_soft_version="x",
+            wifi_hard_version="x",
+            is_online=True,
+            backend=BACKEND_SMART_HOME,
+            product_id=FAKE_PRODUCT_KEY,
+            product_series="ULTRAFIT_AIRJET",
+        )
+    }


### PR DESCRIPTION
Fixes the setup failure reported in #135. Newer "Bestway Connect" devices (2025+ UltraFit) no longer produce an `RW_Share_` code -- their "Share device" QR is now a `https://smart-spa-<region>-app.bestwaycorp.com/.../shareDevice/index.html?shareId=...` link, which the V02 config flow rejected with *"QR code must start with 'RW_Share_'"*.

### Root cause

These devices live on a third backend -- the Gizwits AEP super-app gateway -- with a different host, auth scheme and device-sharing model than both the Gizwits V01 and AWS IoT V02 backends. Loosening the `RW_Share_` check cannot work: the old `grant_device` endpoint has no record of the new share (it reports `binding_type: home` / code `16009`).

### Change

Adds a self-contained `smart_home` backend that mirrors the `AwsIotApi` interface, so the coordinator and all entities are reused unchanged. It performs:

- anonymous-session login (no username/password; long-lived token),
- share redemption (the share id travels in the URL path),
- device discovery and device-shadow reads, normalised through the existing `normalize_aws_state()` (identical field names),
- plaintext control commands.

### Backwards compatible

The V02 step now accepts the new share link **or** a bare share id **in addition to** the legacy `RW_Share_` code and visitor id, routing each to the correct backend. Existing setups are untouched.

### Error handling

The gateway reports errors as a business `code` inside an HTTP 200 body, so those are checked explicitly (the silent-fallthrough noted in #135) and mapped to clear, translated messages: missing / invalid / expired / already-used share, device not found, API unreachable.

### Security

Share ids, tokens and the full share URL are never logged; the config entry stores only an anonymous session token and a generated phone id.

### Verified on real hardware

An UltraFit (Lay-Z-Spa Toronto, `productKey` FTEW0E, EU) was set up from a new-style share link and controlled from Home Assistant: state read-back, target temperature, heater and filter all work. Bubbles switch on/off correctly; these pumps report a different `wave_state` scale than the older 0/40/100 models, so multi-level (off/medium/max) read-back is not yet mapped for them -- the on/off bubble mode is the reliable choice here. All other backends are unaffected.

### Tests

Adds coverage for share-URL/id parsing (EU/US/bare/missing/invalid/unexpected format), anonymous login, share redemption and its error codes, device discovery, shadow normalisation, control commands, and that `RW_Share_` still routes to the AWS IoT backend. All external calls are mocked; no real credentials or share ids are used. Full suite green; `ruff` + `mypy` clean.

Minimum HA version (2024.10) unchanged -- no new API surface is used.
