### PR TITLE
Translate bubbles select options

### DIFF
--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -13,10 +13,13 @@ from .entity import BestwayEntity, OptimisticValue
 from .features import BubblesStyle, features_for
 from .model import BubblesLevel
 
+# Option values are translation slugs: Home Assistant looks each one up under
+# entity.select.bubbles.state in the translation files, so the UI can show them
+# in the user's language.
 _BUBBLES_OPTIONS = {
-    BubblesLevel.OFF: "OFF",
-    BubblesLevel.MEDIUM: "MEDIUM",
-    BubblesLevel.MAX: "MAX",
+    BubblesLevel.OFF: "off",
+    BubblesLevel.MEDIUM: "medium",
+    BubblesLevel.MAX: "max",
 }
 _BUBBLES_LEVELS = {option: level for level, option in _BUBBLES_OPTIONS.items()}
 
@@ -25,6 +28,7 @@ _BUBBLES_LEVELS = {option: level for level, option in _BUBBLES_OPTIONS.items()}
 # only reads status.bubbles and writes via set_bubbles().
 _BUBBLES_SELECT_DESCRIPTION = SelectEntityDescription(
     key="bubbles",
+    translation_key="bubbles",
     options=list(_BUBBLES_OPTIONS.values()),
     icon=Icon.BUBBLES,
     name="Spa Bubbles",

--- a/custom_components/bestway/translations/de.json
+++ b/custom_components/bestway/translations/de.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Bestway",
+        "data": {
+          "backend": "Gerätegeneration"
+        }
+      }
+    }
+  },
+  "entity": {
+    "select": {
+      "bubbles": {
+        "state": {
+          "off": "Aus",
+          "medium": "Mittel",
+          "max": "Maximum"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Bestway-Optionen",
+        "description": "Legt fest, wie die Integration den Whirlpool in Home Assistant abbildet.",
+        "data": {
+          "bubbles_mode": "Bedienung der Luftsprudler (Airjet V02 / Hydrojet V02)"
+        },
+        "data_description": {
+          "bubbles_mode": "Manche Airjet-V02-Whirlpools haben physisch nur eine Ein-/Aus-Sprudelfunktion, obwohl die Cloud einen dreistufigen Wert annimmt. Wählen Sie die Einstellung, die zu Ihrer Hardware passt. Änderungen greifen nach dem Neuladen der Integration."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/bestway/translations/en.json
+++ b/custom_components/bestway/translations/en.json
@@ -62,5 +62,16 @@
         }
       }
     }
+  },
+  "entity": {
+    "select": {
+      "bubbles": {
+        "state": {
+          "off": "Off",
+          "medium": "Medium",
+          "max": "Max"
+        }
+      }
+    }
   }
 }

--- a/tests/test_availability_and_controls.py
+++ b/tests/test_availability_and_controls.py
@@ -313,11 +313,11 @@ class TestBubblesSelectOptimistic:
         config_entry = MagicMock()
 
         select = ThreeWaySpaBubblesSelect(coordinator, config_entry, "test_device")
-        assert select.current_option == "OFF"
+        assert select.current_option == "off"
 
         # Mirrors what async_select_option does, without the awaited API call.
         select._optimistic.set(BubblesLevel.MAX)
-        assert select.current_option == "MAX"
+        assert select.current_option == "max"
 
     def test_select_optimistic_kept_when_real_state_lags(self):
         """A refresh that hasn't caught up yet must not flicker the select
@@ -339,7 +339,7 @@ class TestBubblesSelectOptimistic:
             select._handle_coordinator_update()
 
         assert select._optimistic.value == BubblesLevel.MAX  # Kept, no flicker
-        assert select.current_option == "MAX"
+        assert select.current_option == "max"
 
     def test_select_optimistic_cleared_when_real_state_matches(self):
         """Optimistic state clears once the cloud confirms the new level."""
@@ -358,7 +358,7 @@ class TestBubblesSelectOptimistic:
             select._handle_coordinator_update()
 
         assert select._optimistic.value is None  # Cleared on confirmation
-        assert select.current_option == "MAX"  # Now reads from the coordinator
+        assert select.current_option == "max"  # Now reads from the coordinator
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_entity_wiring.py
+++ b/tests/test_entity_wiring.py
@@ -157,9 +157,9 @@ async def test_bubbles_switch_on_off_calls_set_bubbles():
 @pytest.mark.parametrize(
     ("option", "level"),
     [
-        ("OFF", BubblesLevel.OFF),
-        ("MEDIUM", BubblesLevel.MEDIUM),
-        ("MAX", BubblesLevel.MAX),
+        ("off", BubblesLevel.OFF),
+        ("medium", BubblesLevel.MEDIUM),
+        ("max", BubblesLevel.MAX),
     ],
 )
 async def test_select_option_calls_set_bubbles(option, level):

--- a/tests/test_select_translations.py
+++ b/tests/test_select_translations.py
@@ -1,0 +1,29 @@
+"""Tests that every select option has a translation entry."""
+
+import json
+from pathlib import Path
+
+from custom_components.bestway.select import _BUBBLES_OPTIONS
+
+TRANSLATIONS = Path("custom_components/bestway/translations")
+
+
+def _states(language: str) -> dict[str, str]:
+    data = json.loads((TRANSLATIONS / f"{language}.json").read_text(encoding="utf-8"))
+    return data["entity"]["select"]["bubbles"]["state"]
+
+
+def test_option_values_are_translation_slugs() -> None:
+    """Option values must be slugs, or Home Assistant cannot look them up."""
+    for option in _BUBBLES_OPTIONS.values():
+        assert option.islower()
+        assert option.replace("_", "").isalnum()
+
+
+def test_every_option_is_translated_in_every_language() -> None:
+    """A missing entry would surface the raw slug in the UI."""
+    for language in sorted(p.stem for p in TRANSLATIONS.glob("*.json")):
+        states = _states(language)
+        for option in _BUBBLES_OPTIONS.values():
+            assert option in states, f"{option} missing from {language}.json"
+            assert states[option].strip()


### PR DESCRIPTION
The three-way bubbles select exposes its options as the literal strings `OFF`/`MEDIUM`/`MAX`, so every UI shows them in English regardless of the user's language. There is currently no `entity` block in the translation files at all.

Home Assistant translates select states by looking the option value up under `entity.select.<key>.state`, which requires slug values plus a `translation_key` on the entity description.

**Changes**
- option values become slugs (`off`/`medium`/`max`)
- `translation_key` added to the select description
- `entity.select.bubbles.state` block added to `en.json`
- `de.json` added — German for the states and the options flow
- two tests: options are slugs, and every language translates every option

The entity `name` is deliberately left in the description, so display names do not change.

**⚠️ Breaking change:** automations calling `select.select_option` with the literal `OFF`/`MEDIUM`/`MAX` need updating to `off`/`medium`/`max`. I see no way to translate the states without it — happy to drop the PR if you consider that too disruptive for existing users.

**Verified locally** (`uv sync` against the repo's own lockfile, Python 3.14.2): baseline `main` 282 passed → with this change **284 passed**; `pre-commit run --all-files` passes all eight hooks.